### PR TITLE
implement qlinear and qlinear_dynamic

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/mkldnn_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/mkldnn_utils.h
@@ -11,6 +11,56 @@
 #include <ATen/native/mkldnn/Utils.h>
 #include <cfloat>
 
+struct PackedLinearWeightsMkldnn : public LinearPackedParamsBase {
+  PackedLinearWeightsMkldnn(
+      std::unique_ptr<ideep::tensor> weight,
+      c10::optional<ideep::tensor> bias,
+      at::Tensor orig_weight,
+      c10::optional<at::Tensor> orig_bias)
+      : weight_(std::move(weight)),
+        bias_(std::move(bias)),
+        orig_weight_(std::move(orig_weight)),
+        orig_bias_(std::move(orig_bias)) {}
+  std::unique_ptr<ideep::tensor> weight_;
+  c10::optional<ideep::tensor> bias_;
+  at::Tensor orig_weight_;
+  c10::optional<at::Tensor> orig_bias_;
+
+  at::Tensor apply(
+      at::Tensor input,
+      double output_scale,
+      int64_t output_zero_point) override;
+  at::Tensor apply_relu(
+      at::Tensor input,
+      double output_scale,
+      int64_t output_zero_point) override;
+
+  at::Tensor apply_dynamic(at::Tensor input, bool reduce_range=false) override;
+  at::Tensor apply_dynamic_relu(at::Tensor input, bool reduce_range=false) override;
+
+  std::tuple<at::Tensor, c10::optional<at::Tensor>> unpack() override;
+
+  c10::optional<at::Tensor> bias() override {
+    return orig_bias_;
+  }
+
+  static c10::intrusive_ptr<LinearPackedParamsBase> prepack(
+      at::Tensor weight,
+      c10::optional<at::Tensor> bias);
+
+ private:
+  template <bool ReluFused>
+  at::Tensor apply_impl(
+      at::Tensor input,
+      double output_scale,
+      int64_t output_zero_point);
+
+  template <bool ReluFused>
+  at::Tensor apply_dynamic_impl(at::Tensor input, bool reduce_range=false);
+
+  void find_min_max(const float* a, float* min, float* max, int len);
+};
+
 template <int kSpatialDim = 2>
 struct PackedConvWeightsMkldnn : public ConvPackedParamsBase<kSpatialDim> {
   PackedConvWeightsMkldnn(

--- a/aten/src/ATen/native/quantized/cpu/mkldnn_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/mkldnn_utils.h
@@ -9,7 +9,6 @@
 #include <c10/core/QScheme.h>
 #include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <ATen/native/mkldnn/Utils.h>
-#include <cfloat>
 
 struct PackedLinearWeightsMkldnn : public LinearPackedParamsBase {
   PackedLinearWeightsMkldnn(

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -815,6 +815,8 @@ at::Tensor PackedConvWeightsMkldnn<kSpatialDim>::apply_impl(
       kSpatialDim == 2,
       func_name, kSpatialDim,
       "d (mkldnn): MKLDNN only supports Conv2d now.");
+  TORCH_CHECK(act.scalar_type() == c10::ScalarType::QUInt8,
+      func_name, " (MKLDNN): data type of input should be QUint8.");
 
   // src
   auto src_dims = act.sizes().vec();

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -853,7 +853,7 @@ at::Tensor PackedConvWeightsMkldnn<kSpatialDim>::apply_impl(
   const ideep::scale_t& src_scales = src.get_scale();
   const ideep::scale_t& weights_scales = weights.get_scale();
   const ideep::scale_t& dst_scales = ideep::scale_t(weights_scales.size(), 1.0/output_scale); // Scales of MKLDNN and PyTorch are reciprocal
-  ideep::attr_t op_attr = kReluFused ? ideep::attr_t() : ideep::attr_t::fuse_relu();
+  ideep::attr_t op_attr = kReluFused ? ideep::attr_t::fuse_relu() : ideep::attr_t();
   op_attr.set_zero_points(DNNL_ARG_SRC, ideep::utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL}); // runtime src zero point
   if (with_bias) {
     auto b = bias_.value();
@@ -868,7 +868,7 @@ at::Tensor PackedConvWeightsMkldnn<kSpatialDim>::apply_impl(
                                         src_scales, weights_scales, dst_scales, op_attr,
                                         dnnl::algorithm::convolution_direct, dnnl::prop_kind::forward_inference,
                                         ideep::u8s8, ideep::engine::cpu_engine());
-}
+  }
 
   return output;
 }

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -389,6 +389,9 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsMkldnn<
   } else {
     TORCH_CHECK(false, "Unsupported qscheme: ", toString(qtype));
   }
+  TORCH_CHECK(
+      wgt_zero_points.size()<=1,
+      "quantized::conv_prepack: MKLDNN only supports 1-dim zero point right now");
 
   // Set runtime src zero point
   auto src_zero_point = {DNNL_RUNTIME_S32_VAL};

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -402,7 +402,8 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsMkldnn<
                                                                                  strides, padding_l, padding_r, dilates, groups,
                                                                                  dnnl::algorithm::convolution_direct, dnnl::prop_kind::forward_inference,
                                                                                  dnnl::memory::data_type::u8, ideep::dims(), op_attr);
-  ideep::tensor wgt = ideep::tensor({dims, dnnl::memory::data_type::s8}, weight.data_ptr());
+  auto weight_copy = weight.clone();
+  ideep::tensor wgt = ideep::tensor({dims, dnnl::memory::data_type::s8}, weight_copy.data_ptr());
   ideep::tensor exp_wgt;
   exp_wgt.init(w_desc);
   exp_wgt.feed_from(wgt);

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -443,7 +443,7 @@ at::Tensor PackedLinearWeightsMkldnn::apply_impl(
   auto input_data_type = input_reshaped.scalar_type() == c10::ScalarType::QInt8 ?
                           dnnl::memory::data_type::s8 : dnnl::memory::data_type::u8;
   auto input_desc = ideep::tensor::desc(input_dims, input_data_type);
-  ideep::attr_t op_attr = ReluFused ? ideep::attr_t() : ideep::attr_t::fuse_relu();
+  ideep::attr_t op_attr = ReluFused ? ideep::attr_t::fuse_relu() : ideep::attr_t();
   ideep::tensor x;
   x.init(input_desc, input.data_ptr());
   x.set_scale(ideep::scale_t(1, 1.0/input.q_scale())); // Scales of MKLDNN and PyTorch are reciprocal

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -430,18 +430,12 @@ at::Tensor PackedLinearWeightsMkldnn::apply_impl(
       input.dim() != 0,
       "mkldnn_linear: input needs to has dim at least 1, input dim ",
       input.dim());
-  if (input.scalar_type() == c10::ScalarType::BFloat16) {
-    TORCH_CHECK(at::mkldnn_bf16_device_check(),
-        "mkldnn_linear: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
-  }
 
-  // reshape first if input dim != 2 and the reshape will cost a memory copy.
   auto input_reshaped =
       dim == 2 ? input : input.reshape({-1, input.size(input.dim() - 1)});
 
   auto input_dims = input_reshaped.sizes().vec();
-  auto input_data_type = input_reshaped.scalar_type() == c10::ScalarType::QInt8 ?
-                          dnnl::memory::data_type::s8 : dnnl::memory::data_type::u8;
+  auto input_data_type = dnnl::memory::data_type::u8;
   auto input_desc = ideep::tensor::desc(input_dims, input_data_type);
   ideep::attr_t op_attr = ReluFused ? ideep::attr_t::fuse_relu() : ideep::attr_t();
   ideep::tensor x;

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -430,6 +430,8 @@ at::Tensor PackedLinearWeightsMkldnn::apply_impl(
       input.dim() != 0,
       "mkldnn_linear: input needs to has dim at least 1, input dim ",
       input.dim());
+  TORCH_CHECK(input.scalar_type() == c10::ScalarType::QUInt8,
+      "qlinear (MKLDNN): data type of input should be QUint8.");
 
   auto input_reshaped =
       dim == 2 ? input : input.reshape({-1, input.size(input.dim() - 1)});

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/packed_params.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <ATen/native/quantized/cpu/mkldnn_utils.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/custom_class.h>
 #include <torch/library.h>
@@ -417,6 +418,84 @@ at::Tensor PackedLinearWeightsQnnp::apply_relu(
 }
 
 #endif // USE_PYTORCH_QNNPACK
+
+#if AT_MKLDNN_ENABLED()
+template <bool ReluFused>
+at::Tensor PackedLinearWeightsMkldnn::apply_impl(
+    at::Tensor input,
+    double output_scale,
+    int64_t output_zero_point) {
+  const int64_t dim = input.dim();
+  TORCH_CHECK(
+      input.dim() != 0,
+      "mkldnn_linear: input needs to has dim at least 1, input dim ",
+      input.dim());
+  if (input.scalar_type() == c10::ScalarType::BFloat16) {
+    TORCH_CHECK(at::mkldnn_bf16_device_check(),
+        "mkldnn_linear: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+  }
+
+  // reshape first if input dim != 2 and the reshape will cost a memory copy.
+  auto input_reshaped =
+      dim == 2 ? input : input.reshape({-1, input.size(input.dim() - 1)});
+
+  auto input_dims = input_reshaped.sizes().vec();
+  auto input_data_type = input_reshaped.scalar_type() == c10::ScalarType::QInt8 ?
+                          dnnl::memory::data_type::s8 : dnnl::memory::data_type::u8;
+  auto input_desc = ideep::tensor::desc(input_dims, input_data_type);
+  ideep::attr_t op_attr = ReluFused ? ideep::attr_t() : ideep::attr_t::fuse_relu();
+  ideep::tensor x;
+  x.init(input_desc, input.data_ptr());
+  x.set_scale(ideep::scale_t(1, 1.0/input.q_scale())); // Scales of MKLDNN and PyTorch are reciprocal
+  x.set_zero_point(std::vector<int32_t>(1, input.q_zero_point()));
+  auto w = *(weight_.get());
+  auto dst_dims = {x.get_dim(0), w.get_dim(1)};
+  const ideep::scale_t& src_scales = x.get_scale();
+  const ideep::scale_t& weights_scales = w.get_scale();
+  const ideep::scale_t& dst_scales = ideep::scale_t(1, 1.0/output_scale); // Scales of MKLDNN and PyTorch are reciprocal
+  const std::vector<int32_t>& dst_zero_point = std::vector<int32_t>(1, output_zero_point);
+  // Compute: Use ideep::matmul_forward to support asymmetric quantization
+  // Allocate output Tensor
+  at::Tensor output = at::_empty_affine_quantized(
+      dst_dims,
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      output_scale,
+      output_zero_point);
+  if (output.numel() == 0) {
+    return output;
+  }
+  ideep::tensor y({dst_dims, ideep::tensor::data_type::u8, {output.strides().cbegin(), output.strides().cend()}},
+                  output.data_ptr());
+  y.set_zero_point(dst_zero_point);
+  if (bias_.has_value()) {
+    const ideep::tensor b = bias_.value();
+    TORCH_CHECK(b.get_dim(0) == 1, "bias should be a vector (1D Tensor), but got [", b.get_dims(), "]");
+    TORCH_CHECK(
+        b.get_dim(1) == w.get_dim(1), "bias should have N elements: " + std::to_string(w.get_dim(1)), ", but got ", b.get_dim(1));
+    ideep::matmul_forward::compute(x, w, b, y, 1.0f, 1.0f, src_scales, weights_scales, dst_scales, op_attr);
+  } else {
+    ideep::matmul_forward::compute(x, w, y, 1.0f, 1.0f, src_scales, weights_scales, dst_scales, op_attr);
+  }
+  auto out_sizes = input.sizes().vec();
+  out_sizes.back() = w.get_dim(1);
+  return output.reshape(out_sizes);
+}
+
+at::Tensor PackedLinearWeightsMkldnn::apply(
+    at::Tensor input,
+    double output_scale,
+    int64_t output_zero_point) {
+  return apply_impl<false>(std::move(input), output_scale, output_zero_point);
+}
+
+at::Tensor PackedLinearWeightsMkldnn::apply_relu(
+    at::Tensor input,
+    double output_scale,
+    int64_t output_zero_point) {
+  return apply_impl<true>(std::move(input), output_scale, output_zero_point);
+}
+
+#endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/packed_params.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <ATen/native/quantized/cpu/mkldnn_utils.h>
 #include <ATen/native/quantized/cpu/quant_utils.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/library.h>
@@ -414,6 +415,107 @@ void PackedLinearWeightFp16::set_bias(c10::optional<at::Tensor> bias) {
 
 #endif // USE_FBGEMM
 
+#if AT_MKLDNN_ENABLED()
+template <bool ReluFused>
+at::Tensor PackedLinearWeightsMkldnn::apply_dynamic_impl(at::Tensor input, bool reduce_range) {
+  using at::Tensor;
+  // fp32 * int8 -> fp32 (with quantization on activation, and dequantization on the result).
+
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "The dimension of input tensor should be larger than or equal to 2");
+
+  // Input -> uint8
+  const int64_t dim = input.dim();
+  auto input_reshaped =
+      dim == 2 ? input : input.reshape({-1, input.size(input.dim() - 1)});
+  auto input_dims = input_reshaped.sizes().vec();
+  auto input_data_type = dnnl::memory::data_type::f32;
+  auto input_desc = ideep::tensor::desc(input_dims, input_data_type);
+  ideep::tensor x;
+  x.init(input_desc, input.data_ptr());
+  float x_max, x_min;
+  const int precision = 8;
+  find_min_max(input_reshaped.data_ptr<float>(), &x_min, &x_max, input.numel());
+  auto q_params = quant_utils::ChooseQuantizationParams(
+      /*min=*/x_min,
+      /*max=*/x_max,
+      /*qmin=*/0,
+      /*qmax=*/(1 << precision) - 1,
+      /*preserve_sparsity=*/false,
+      /*force_scale_power_of_two=*/false,
+      /*reduce_range=*/reduce_range);
+  x.set_scale(ideep::scale_t(1, 1.0/q_params.scale)); // use reciprocal for MKLDNN
+  x.set_zero_point(std::vector<int32_t>(1, q_params.zero_point));
+  // weights, dst
+  auto w = *(weight_.get());
+  auto dst_dims = {x.get_dim(0), w.get_dim(1)};
+  const ideep::scale_t& src_scales = x.get_scale();
+  const ideep::scale_t& weights_scales = w.get_scale();
+  // Compute -> f32
+  // Use ideep::matmul_forward instead of ideep::inner_product_forward, since the latter does not support asymmetric quantization
+  // Allocate output Tensor
+  at::Tensor output = at::empty(dst_dims, input.options().dtype(at::kFloat));
+  if (output.numel() == 0) return output;
+  ideep::tensor y({dst_dims, ideep::tensor::data_type::f32, {output.strides().cbegin(), output.strides().cend()}},
+                  output.data_ptr());
+  if (bias_.has_value()) {
+    const ideep::tensor b = bias_.value();
+    ideep::matmul_forward::compute(x, w, b, y, 1.0f, 1.0f, src_scales, weights_scales);
+  } else {
+    ideep::matmul_forward::compute(x, w, y, 1.0f, 1.0f, src_scales, weights_scales);
+  }
+  auto out_sizes = input.sizes().vec();
+  out_sizes.back() = w.get_dim(1);
+  return output.reshape(out_sizes);
+}
+
+at::Tensor PackedLinearWeightsMkldnn::apply_dynamic(at::Tensor input, bool reduce_range) {
+  return apply_dynamic_impl</*ReluFused=*/false>(std::move(input), reduce_range);
+}
+
+at::Tensor PackedLinearWeightsMkldnn::apply_dynamic_relu(at::Tensor input, bool reduce_range) {
+  return apply_dynamic_impl</*ReluFused=*/true>(std::move(input), reduce_range);
+}
+
+void PackedLinearWeightsMkldnn::find_min_max(const float* a, float* min, float* max, int len) {
+  if (len <= 0) {
+    *min = 0.0f;
+    *max = 0.0f;
+    return;
+  }
+
+  float temp_min = *a, temp_max = *a;
+  int i = 0;
+
+#ifdef __AVX__
+  __m256 min_v = _mm256_set1_ps(*a), max_v = _mm256_set1_ps(*a);
+  constexpr int VLEN = 8;
+  if (len >= VLEN) {
+    for (; i < len / VLEN * VLEN; i += VLEN) {
+      min_v = _mm256_min_ps(min_v, _mm256_loadu_ps(a + i));
+      max_v = _mm256_max_ps(max_v, _mm256_loadu_ps(a + i));
+    }
+
+    float min_buf[VLEN], max_buf[VLEN];
+    _mm256_storeu_ps(min_buf, min_v);
+    _mm256_storeu_ps(max_buf, max_v);
+    for (int j = 0; j < VLEN; ++j) {
+      temp_min = std::min(temp_min, min_buf[j]);
+      temp_max = std::max(temp_max, max_buf[j]);
+    }
+  }
+#endif
+
+  for (; i < len; i++) {
+    temp_min = std::min(temp_min, a[i]);
+    temp_max = std::max(temp_max, a[i]);
+  }
+  *min = temp_min;
+  *max = temp_max;
+}
+#endif // #if AT_MKLDNN_ENABLED()
+
 namespace at {
 namespace native {
 namespace {
@@ -472,6 +574,16 @@ TORCH_LIBRARY_IMPL(quantized, CPU, m) {
 }
 
 TORCH_LIBRARY_IMPL(_quantized, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("_quantized::linear_dynamic"), TORCH_FN(QLinearDynamicInt8<false>::run));
+}
+
+TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_dynamic"), TORCH_FN(QLinearDynamicInt8<false>::run));
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_relu_dynamic"), TORCH_FN(QLinearDynamicInt8<true>::run));
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_dynamic_fp16"), TORCH_FN(QLinearDynamicFp16<false>::run));
+}
+
+TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("_quantized::linear_dynamic"), TORCH_FN(QLinearDynamicInt8<false>::run));
 }
 

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -424,6 +424,8 @@ at::Tensor PackedLinearWeightsMkldnn::apply_dynamic_impl(at::Tensor input, bool 
   TORCH_CHECK(
       input.dim() >= 2,
       "The dimension of input tensor should be larger than or equal to 2");
+  TORCH_CHECK(input.scalar_type() == c10::ScalarType::Float,
+      "qlinear_dynamic (MKLDNN): data type of input should be float.");
 
   // Input -> uint8
   const int64_t dim = input.dim();

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/packed_params.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <ATen/native/quantized/cpu/mkldnn_utils.h>
 #include <ATen/native/quantized/cpu/quant_utils.h>
 #include <ATen/quantized/Quantizer.h>
 #include <torch/custom_class.h>
@@ -196,6 +197,77 @@ c10::intrusive_ptr<LinearPackedParamsBase> PackedLinearWeightFp16::prepack(
 }
 #endif // USE_FBGEMM
 
+#if AT_MKLDNN_ENABLED()
+c10::intrusive_ptr<LinearPackedParamsBase> PackedLinearWeightsMkldnn::prepack(
+    at::Tensor weight,
+    c10::optional<at::Tensor> bias) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "The weight tensor for quantized::linear_prepack (mkldnn) should"
+      " be 2-dimensional.");
+  // Weight
+  std::vector<int64_t> dims = weight.sizes().vec();
+  auto N = weight.size(0);
+  std::vector<int32_t> wgt_zero_points;
+  ideep::scale_t wgt_scales;
+  const auto qtype = weight.qscheme();
+  if (qtype == c10::kPerTensorAffine) {
+    TORCH_CHECK(
+        weight.q_zero_point() == 0,
+        "quantized::linear_prepack: MKLDNN only supports symmetric quantization of weight,"
+        " whose zero point must be 0.");
+    wgt_zero_points = std::vector<int32_t>(1, weight.q_zero_point());
+    wgt_scales = ideep::scale_t(1, 1.0/weight.q_scale()); // Scales of MKLDNN and PyTorch are reciprocal
+  } else if (qtype == c10::kPerChannelAffine) {
+    wgt_zero_points.resize(N);
+    wgt_scales.resize(N);
+    for (int i = 0; i < N; ++i) {
+      wgt_zero_points[i] = weight.q_per_channel_zero_points()[i].item<int32_t>();
+      TORCH_CHECK(
+          wgt_zero_points[i] == 0,
+          "quantized::linear_prepack: MKLDNN only supports symmetric quantization of weight,"
+          " whose zero point must be 0.");
+      wgt_scales[i] = 1.0f / weight.q_per_channel_scales()[i].item<float>(); // Scales of MKLDNN and PyTorch are reciprocal
+    }
+  } else {
+    TORCH_CHECK(false, "Unsupported qscheme: ", toString(qtype));
+  }
+  TORCH_CHECK(
+      wgt_zero_points.size()<=1,
+      "quantized::linear_prepack: MKLDNN only supports 1-dim zero point right now");
+
+  // Prepack weight
+  auto w_desc = ideep::matmul_forward::expected_weights_desc(dims, dnnl::memory::data_type::s8,
+                                                             dnnl::memory::data_type::u8);
+  ideep::tensor wgt = ideep::tensor({dims, dnnl::memory::data_type::s8}, weight.data_ptr());
+  ideep::tensor exp_wgt;
+  exp_wgt.init(w_desc);
+  exp_wgt.feed_from(wgt);
+  exp_wgt.transpose_(0, 1); // MKLDNN requires transposed weight
+  ideep::tensor * packed_weight_p = new ideep::tensor(exp_wgt);
+  packed_weight_p->set_scale(wgt_scales);
+  packed_weight_p->set_zero_point(wgt_zero_points);
+  std::unique_ptr<ideep::tensor> weight_ptr(packed_weight_p);
+  // Bias
+  c10::optional<ideep::tensor> mkldnn_bias{c10::nullopt};
+  if (bias.has_value()) {
+    auto bias_size = bias.value().sizes().vec();
+    bias_size.insert(bias_size.begin(), 1);
+    auto bias_desc = ideep::tensor::desc(bias_size, dnnl::memory::data_type::f32);
+    ideep::tensor packed_bias;
+    packed_bias.init(bias_desc, bias.value().data_ptr());
+    mkldnn_bias = c10::optional<ideep::tensor>(packed_bias);
+  }
+  auto ret_ptr = c10::make_intrusive<PackedLinearWeightsMkldnn>(
+      PackedLinearWeightsMkldnn{
+        std::move(weight_ptr),
+        mkldnn_bias,
+        weight,
+        bias});
+  return ret_ptr;
+}
+#endif // #if AT_MKLDNN_ENABLED()
+
 namespace at {
 namespace native {
 
@@ -225,6 +297,11 @@ class QLinearPackWeightInt8 final {
           std::move(weight), std::move(bias));
     }
 #endif
+#if AT_MKLDNN_ENABLED()
+    if (ctx.qEngine() == at::QEngine::MKLDNN) {
+      return PackedLinearWeightsMkldnn::prepack(std::move(weight), std::move(bias));
+    }
+#endif // #if AT_MKLDNN_ENABLED()
     TORCH_CHECK(
         false,
         "Didn't find engine for operation quantized::linear_prepack ",
@@ -252,6 +329,14 @@ class QLinearPackWeightFp16 final {
           "not supported by QNNPACK");
     }
 #endif // USE_PYTORCH_QNNPACK
+#if AT_MKLDNN_ENABLED()
+    if (ctx.qEngine() == at::QEngine::MKLDNN) {
+      TORCH_CHECK(
+          false,
+          "quantized::linear_prepack_fp16 is currently "
+          "not supported by MKLDNN");
+    }
+#endif // #if AT_MKLDNN_ENABLED()
     TORCH_CHECK(
         false,
         "Didn't find engine for operation quantized::linear_prepack_fp16 ",
@@ -285,6 +370,16 @@ class QLinearPackWeightInt8Legacy final {
       return cpp_custom_type_hack::create(std::move(wrapped), options);
     }
 #endif // USE_PYTORCH_QNNPACK
+#if AT_MKLDNN_ENABLED()
+    if (ctx.qEngine() == at::QEngine::MKLDNN) {
+      auto prepacked =
+          PackedLinearWeightsMkldnn::prepack(std::move(weight), std::move(bias));
+      auto wrapped =
+          std::make_unique<c10::intrusive_ptr<LinearPackedParamsBase>>(
+              std::move(prepacked));
+      return cpp_custom_type_hack::create(std::move(wrapped), options);
+    }
+#endif // #if AT_MKLDNN_ENABLED()
     TORCH_CHECK(
         false,
         "Didn't find engine for operation quantized::linear_prepack ",
@@ -315,6 +410,14 @@ class QLinearPackWeightFp16Legacy final {
           "not supported by QNNPACK");
     }
 #endif // USE_PYTORCH_QNNPACK
+#if AT_MKLDNN_ENABLED()
+    if (ctx.qEngine() == at::QEngine::MKLDNN) {
+      TORCH_CHECK(
+          false,
+          "quantized::linear_prepack_fp16 is currently "
+          "not supported by MKLDNN");
+    }
+#endif // #if AT_MKLDNN_ENABLED()
     TORCH_CHECK(
         false,
         "Didn't find engine for operation quantized::linear_prepack_fp16 ",

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -239,7 +239,8 @@ c10::intrusive_ptr<LinearPackedParamsBase> PackedLinearWeightsMkldnn::prepack(
   // Prepack weight
   auto w_desc = ideep::matmul_forward::expected_weights_desc(dims, dnnl::memory::data_type::s8,
                                                              dnnl::memory::data_type::u8);
-  ideep::tensor wgt = ideep::tensor({dims, dnnl::memory::data_type::s8}, weight.data_ptr());
+  auto weight_copy = weight.clone();
+  ideep::tensor wgt = ideep::tensor({dims, dnnl::memory::data_type::s8}, weight_copy.data_ptr());
   ideep::tensor exp_wgt;
   exp_wgt.init(w_desc);
   exp_wgt.feed_from(wgt);

--- a/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/packed_params.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <ATen/native/quantized/cpu/mkldnn_utils.h>
 #include <torch/custom_class.h>
 #include <torch/library.h>
 
@@ -73,6 +74,13 @@ std::tuple<at::Tensor, c10::optional<at::Tensor>> PackedLinearWeightFp16::
   return std::make_tuple(unpacked_weight.to(at::kFloat), bias_);
 }
 #endif // USE_FBGEMM
+
+#if AT_MKLDNN_ENABLED()
+std::tuple<at::Tensor, c10::optional<at::Tensor>> PackedLinearWeightsMkldnn::unpack() {
+  return std::tuple<at::Tensor, c10::optional<at::Tensor>>(
+      orig_weight_, orig_bias_);
+}
+#endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
 namespace native {


### PR DESCRIPTION
**Features**
Implement qlinear, including:
- qlinear
- qlinear_relu
- qlinear_dynamic
- qlinear_relu_dynamic

For qlinear_dynamic (including relu-fused), need to determine the proper scale and zero point at runtime. The implementation aligns with FBGEMM. When finding the max and min values of input, AVX feature is used to boost the process. (using the same code as FBGEMM's)

**Test result**
Now running pytorch/test/test_quantization.py, the following errors will occur due to incomplete implementation of ops and insufficient support of oneDNN:
- quantized::linear_prepack_fp16 is currently not supported by MKLDNN
- quantized::linear_prepack: MKLDNN only supports symmetric quantization of weight, whose zero point must be 0.
- quantized::conv_prepack: MKLDNN only supports symmetric quantization of weight, whose zero point must be 0.
- quantized::conv_prepack: MKLDNN only supports 1-dim zero point right now
- quantized::linear_prepack: MKLDNN only supports 1-dim zero point right now
- MKLDNN only supports conv2d_unpack right now.
- quantized::conv3d (mkldnn): MKLDNN only supports Conv2d now.
- Quantized::conv_prepack: MKLDNN does not support qconv_transpose right now.

There are also a few failures when running this test.
When running qlinear/qlinear_dynamic in a loop, MKLDNN showed lower speed than FBGEMM. MKLDNN took ~ 3x time.