### PR TITLE
Convert input to contiguous format for qconv/qlinear of MKLDNN

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -820,11 +820,12 @@ at::Tensor PackedConvWeightsMkldnn<kSpatialDim>::apply_impl(
       func_name, " (MKLDNN): data type of input should be QUint8.");
 
   // src
-  auto src_dims = act.sizes().vec();
+  auto act_contig = act.contiguous();
+  auto src_dims = act_contig.sizes().vec();
   auto src_data_type = dnnl::memory::data_type::u8;
   auto src_desc = ideep::tensor::desc(src_dims, src_data_type);
   ideep::tensor src;
-  src.init(src_desc, act.data_ptr());
+  src.init(src_desc, act_contig.data_ptr());
   src.set_scale(ideep::scale_t(1, 1.0/act.q_scale())); // Scales of MKLDNN and PyTorch are reciprocal
   src.set_zero_point(std::vector<int32_t>(1, act.q_zero_point()));
   // weights & bias

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -433,8 +433,9 @@ at::Tensor PackedLinearWeightsMkldnn::apply_impl(
   TORCH_CHECK(input.scalar_type() == c10::ScalarType::QUInt8,
       "qlinear (MKLDNN): data type of input should be QUint8.");
 
+  auto input_contig = input.contiguous();
   auto input_reshaped =
-      dim == 2 ? input : input.reshape({-1, input.size(input.dim() - 1)});
+      dim == 2 ? input_contig : input_contig.reshape({-1, input.size(input.dim() - 1)});
 
   auto input_dims = input_reshaped.sizes().vec();
   auto input_data_type = dnnl::memory::data_type::u8;

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -428,6 +428,7 @@ at::Tensor PackedLinearWeightsMkldnn::apply_dynamic_impl(at::Tensor input, bool 
       "qlinear_dynamic (MKLDNN): data type of input should be float.");
 
   // Input -> uint8
+  auto input_contig = input.contiguous();
   const int64_t dim = input.dim();
   auto input_reshaped =
       dim == 2 ? input : input.reshape({-1, input.size(input.dim() - 1)});
@@ -436,7 +437,7 @@ at::Tensor PackedLinearWeightsMkldnn::apply_dynamic_impl(at::Tensor input, bool 
   auto input_desc = ideep::tensor::desc(input_dims, input_data_type);
   ideep::attr_t op_attr = ReluFused ? ideep::attr_t::fuse_relu() : ideep::attr_t();
   ideep::tensor x;
-  x.init(input_desc, input.data_ptr());
+  x.init(input_desc, input_contig.data_ptr());
   float x_max, x_min;
   const int precision = 8;
   find_min_max(input_reshaped.data_ptr<float>(), &x_min, &x_max, input.numel());


### PR DESCRIPTION
To avoid errors if input is not in contiguous format.