### PR TITLE
Enable the POC of conv2d relu external call inside inductor

### DIFF
--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -257,7 +257,7 @@ class TestQuantizePT2EModels(QuantizationTestCase):
                 return self.relu(x)
 
         with override_quantized_engine("x86"):
-            example_inputs = (torch.randn(1, 3, 224, 224),)
+            example_inputs = (torch.randn(1, 3, 16, 16),)
             m = Mod().eval()
             # program capture
             m, guards = torchdynamo.export(
@@ -278,6 +278,8 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             m = convert_pt2e(m)
             after_quant_result = m(*example_inputs)
 
+            self.assertTrue(torch.allclose(before_fusion_result, after_quant_result, rtol=5e-02, atol=5e-02))
+
             # A few ops in EXIR are not supported. Set nopython=False to make it work
             run = torch._dynamo.optimize(compile_fx, nopython=False)(m)
 
@@ -289,4 +291,6 @@ class TestQuantizePT2EModels(QuantizationTestCase):
 
             # second run
             inductor_result = run(*example_inputs)
+
+            self.assertTrue(torch.allclose(before_fusion_result, inductor_result, rtol=5e-02, atol=5e-02))
 

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -597,7 +597,7 @@ def fuse_quantization(gm: torch.fx.GraphModule):
     if not is_quantized_graph_module(gm):
         return gm
 
-    # gm = fuse_reference_quantized_conv_relu(gm)
+    gm = fuse_reference_quantized_conv_relu(gm)
 
     return gm
 
@@ -635,9 +635,8 @@ def fuse_reference_quantized_conv_relu(gm: torch.fx.GraphModule):
             y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
         # TODO: aten.convolution can be used for all conv1d/2d/3d but the spatial dim info
         # is lost. Here we hardcode conv2d for experiment.
-        quantized = torch.ops.quantized
-        w_packed = quantized.conv2d_prepack(qw, bias, stride, padding, dilation, groups)
-        qy = quantized.conv2d_relu.new(qx, w_packed, y_scale, y_zp)
+        qy = quantized_decomposed.conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                                                       bias, stride, padding, dilation, groups, y_scale, y_zp)
         return qy
 
     subgraph_rewriter.replace_pattern(gm, pattern, replacement)

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -2,6 +2,7 @@ import torch
 from torch.library import Library, impl
 from torch.ao.quantization import MinMaxObserver
 from typing import Tuple
+from torch._meta_registrations import calc_conv_nd_return_shape
 
 # Note: decomposed means decomposed quantized tensor, using decomposed so that the
 # name is not too long
@@ -174,6 +175,41 @@ def dequantize_per_tensor_tensor_meta(input, scale, zero_point, quant_min, quant
     else:
         raise ValueError(f"Unsupported dtype in dequantize_per_tensor: {dtype}")
 
+quantized_decomposed_lib.define(
+    "conv2d_relu_inductor.tensor(Tensor qx, Tensor input_scale, Tensor input_zero_point,"
+    "Tensor qw, Tensor weight_scale, Tensor weight_zero_point, int w_axis, Tensor? bias,"
+    "int[] stride, int[] padding, int[] dilation, int groups, Tensor output_scale, Tensor output_zero_point) -> Tensor")
+@impl(quantized_decomposed_lib, "conv2d_relu_inductor.tensor", "CPU")
+def conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                         bias, stride, padding, dilation, groups, output_scale, output_zero_point):
+    quantized = torch.ops.quantized
+
+    # Input Workaround to test feasibility
+    # Re-constructure the qw and qx
+    real_qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
+    real_qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
+
+    w_packed = quantized.conv2d_prepack(real_qw, bias, stride, padding, dilation, groups)
+    qy = quantized.conv2d_relu.new(real_qx, w_packed, output_scale, output_zero_point)
+
+    # Output Workround: Return a int8 tensor without quantizer
+    return qy.int_repr()
+
+@impl(quantized_decomposed_lib, "conv2d_relu_inductor.tensor", "Meta")
+def conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
+                         stride, padding, dilation, groups, output_scale, output_zero_point):
+    shape_out = calc_conv_nd_return_shape(
+        qx,
+        qw,
+        stride,
+        padding,
+        dilation,
+        False,
+        groups,
+        None,
+    )
+    out = qx.new_empty(shape_out).to(memory_format=torch.channels_last)
+    return out
 
 quantized_decomposed_lib.define(
     "choose_qparams.tensor(Tensor input, int quant_min, int quant_max, "


### PR DESCRIPTION
This PR is for the POC of int8 inductor conv2d relu case to prove the feasibility of inductor int8 path. 

**Test Command**
```
python -m pytest quantization/fx/test_quantize_pt2e.py -k test_conv2d_inductor_backend
``` 
