### PR TITLE
Inductor quantization: prepack weight and bias for conv

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -19,6 +19,7 @@
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/library.h>
 #include <ATen/quantized/Quantizer.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -1607,6 +1608,160 @@ static at::Tensor onednn_conv_int8_with_cpu_tensors(
   }
   return output;
 }
+
+template <bool kReluFused>
+static at::Tensor onednn_conv_int8_with_prepacked_weight_bias(
+    at::Tensor act, // contains quantized values but not QTensor
+    double act_scale,
+    int64_t act_zero_point,
+    at::Tensor weight, // MKLDNN tensor with quantized values
+    at::Tensor weight_scales,
+    at::Tensor weight_zero_points,
+    c10::optional<at::Tensor> bias, // Bias is packed if not None
+    torch::List<int64_t> stride,
+    torch::List<int64_t> padding,
+    torch::List<int64_t> dilation,
+    int64_t groups,
+    double output_scale,
+    int64_t output_zero_point) {
+  /*********************************/
+  /*          Checks               */
+  /*********************************/
+  int kSpatialDim = act.dim() - 2;
+  bool is_1d = (1 == kSpatialDim);
+  std::string func_name = "Inductor int8 conv";
+  func_name += std::to_string(kSpatialDim) + "d";
+  if (kReluFused) {
+    func_name += "_relu";
+  }
+  func_name += "_with_prepacked_weight";
+  // For conv1d, compute as conv2d then squeeze output
+  if (kSpatialDim == 1) {
+    kSpatialDim += 1;
+  }
+  TORCH_CHECK(
+    weight.is_mkldnn(),
+    func_name, ": Weight should be prepacked as an MKLDNN tensor"
+  );
+  if (is_1d) {
+    // N, C, L -> N, C, 1, L
+    act = act.unsqueeze(quant_utils::kConv1dSqueezeDim + 2);
+    stride = quant_utils::MakeArgForConv1d(stride, 1);
+    padding = quant_utils::MakeArgForConv1d(padding, 0);
+    dilation = quant_utils::MakeArgForConv1d(dilation, 1);
+  }
+  TORCH_CHECK(
+      act.scalar_type() == c10::ScalarType::Byte,
+      func_name, ": Input tensor should have uint8 (unsigned char) data type");
+  TORCH_CHECK(
+      weight.scalar_type() == c10::ScalarType::Char,
+      func_name, ": Weight tensor should have int8 (char) data type");
+  TORCH_CHECK(
+      weight.ndimension() == kSpatialDim + 2,
+      func_name, ": Weights are expected to have ", kSpatialDim + 2, " dimensions");
+  TORCH_CHECK(
+      stride.size() == kSpatialDim,
+      func_name, ": stride should contain ", kSpatialDim, " elements for ",
+      kSpatialDim, "D convolution.");
+  TORCH_CHECK(
+      padding.size() == kSpatialDim,
+      func_name, ": Specify front/top/left padding only. "
+      "end/bottom/right padding assumed to be equal to front/top/left");
+  TORCH_CHECK(
+      dilation.size() == kSpatialDim,
+      func_name, ": dilation should contain ", kSpatialDim, " elements for ",
+      kSpatialDim, "D convolution.");
+
+  // Parameters
+  // Scales of ONEDNN and PyTorch are reciprocal
+  const ideep::scale_t& src_scales = ideep::scale_t(1, 1.0 / act_scale);
+  double inv_output_scale = 1.0 / output_scale;
+  ideep::scale_t weights_scales(weight_scales.numel());
+  for (int i = 0; i < weight_scales.numel(); ++i) {
+    weights_scales[i] = 1.0 / weight_scales[i].item().toDouble();
+  }
+  const ideep::zero_point_t src_zero_points = ideep::zero_point_t(1, act_zero_point);
+  const ideep::zero_point_t dst_zero_points = ideep::zero_point_t(1, output_zero_point);
+
+  // Weight
+  auto packed_weight = at::native::itensor_from_mkldnn(weight);
+  // Here we check weight desc and reorder weight if necessary
+  // because input shape may change and so does weight layout
+  auto op_attr = ideep::attr_t();
+  ideep::scale_t bias_scales, op_scales;
+  std::tie(bias_scales, op_scales) = ideep::utils::compute_scales(
+      src_scales[0], inv_output_scale, weights_scales);
+  int scale_size = weights_scales.size();
+  op_attr.set_output_scales(ideep::utils::op_scale_mask(scale_size), op_scales);
+  op_attr.set_zero_points(DNNL_ARG_SRC, 0, src_zero_points);
+  op_attr.set_zero_points(DNNL_ARG_DST, 0, dst_zero_points);
+  auto w_desc = ideep::convolution_forward::expected_weights_desc(
+      weight.sizes().vec(), dnnl::memory::data_type::s8,
+      stride.vec(), padding.vec(), padding.vec(), dilation.vec(), groups,
+      dnnl::algorithm::convolution_direct, dnnl::prop_kind::forward_inference,
+      dnnl::memory::data_type::u8, act.sizes().vec(), op_attr, /*is_channels_last=*/true);
+  ideep::tensor expected_weight = packed_weight.reorder_if_differ_in(w_desc);
+
+  // Bias
+  c10::optional<ideep::tensor> onednn_bias{c10::nullopt};
+  bool with_bias = bias.has_value();
+  if (with_bias) {
+    onednn_bias = at::native::itensor_from_mkldnn(bias.value());
+  }
+  const auto& expected_bias = with_bias ? onednn_bias.value() : ideep::tensor();
+
+  /*********************************/
+  /*        Computation            */
+  /*********************************/
+  // src
+  auto act_contig = act.contiguous(kSpatialDim == 2 ?
+                                   c10::MemoryFormat::ChannelsLast :
+                                   c10::MemoryFormat::ChannelsLast3d);
+  auto src_dims = act_contig.sizes().vec();
+  auto src_data_type = dnnl::memory::data_type::u8;
+  auto src_desc = ideep::tensor::desc(src_dims, src_data_type,
+      kSpatialDim == 2 ? ideep::format_tag::nhwc : ideep::format_tag::ndhwc);
+  ideep::tensor src;
+  src.init(src_desc, act_contig.data_ptr());
+  // dst
+  const std::vector<int64_t>& input_size = src.get_dims();
+  const auto& kernel_size = expected_weight.get_dims();
+  std::vector<int64_t> output_sizes;
+  output_sizes = at::native::conv_output_size(input_size, kernel_size, padding.vec(), stride.vec(), dilation.vec());
+  ideep::dims dst_dims = ideep::dims({output_sizes.cbegin(), output_sizes.cend()});
+  // Output is not a quantized tensor but data type is uint8
+  at::Tensor output = at::empty(
+    dst_dims,
+    device(c10::kCPU)
+        .dtype(c10::kByte)
+        .memory_format(kSpatialDim == 2 ?
+            c10::MemoryFormat::ChannelsLast :
+            c10::MemoryFormat::ChannelsLast3d)
+  );
+  if (output.numel() == 0) {
+    return output;
+  }
+  ideep::tensor dst({dst_dims, ideep::tensor::data_type::u8, {output.strides().cbegin(), output.strides().cend()}},
+                    output.data_ptr());
+
+  // attr
+  op_attr = kReluFused ? ideep::attr_t::fuse_relu() : ideep::attr_t();
+  // Weight and bias are prepacked, so set reorder_weight as false here
+  ideep::convolution_forward::compute<true, false>(
+      src, expected_weight, expected_bias, dst_dims, dst,
+      stride.vec(), dilation.vec(), padding.vec(), padding.vec(), groups,
+      src_scales, weights_scales, ideep::scale_t(1, inv_output_scale),
+      src_zero_points, dst_zero_points, op_attr,
+      dnnl::algorithm::convolution_direct,
+      dnnl::prop_kind::forward_inference,
+      ideep::u8s8, ideep::engine::cpu_engine());
+  if (is_1d) {
+    output.squeeze_(quant_utils::kConv1dSqueezeDim + 2);
+    return output;
+  }
+  return output;
+}
+
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
@@ -1762,6 +1917,31 @@ class ConvInt8CpuTensor final {
 #endif
     TORCH_CHECK(false, "Unimplemented (int8 conv with CPU tensors)");
   } // run
+
+  static Tensor run_with_packed_weight_bias(
+      Tensor act, // contains quantized values but not QTensor
+      double act_scale,
+      int64_t act_zero_point,
+      Tensor weight, // contains quantized values but not QTensor
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      c10::optional<Tensor> bias,
+      torch::List<int64_t> stride,
+      torch::List<int64_t> padding,
+      torch::List<int64_t> dilation,
+      int64_t groups,
+      double output_scale,
+      int64_t output_zero_point) {
+#if AT_MKLDNN_ENABLED()
+    return onednn_conv_int8_with_prepacked_weight_bias<kReluFused>(
+        act, act_scale, act_zero_point,
+        weight, weight_scales, weight_zero_points,
+        bias, stride, padding, dilation,
+        groups, output_scale, output_zero_point
+    );
+#endif
+    TORCH_CHECK(false, "Unimplemented (int8 conv with packed weight and bias)");
+  }
 };
 
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
@@ -1790,6 +1970,10 @@ TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
 TORCH_LIBRARY_IMPL(quantized, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv_int8_cpu_tensor"),      ConvInt8CpuTensor<false>::run);
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv_relu_int8_cpu_tensor"), ConvInt8CpuTensor<true>::run);
+}
+TORCH_LIBRARY_IMPL(quantized, MkldnnCPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::conv_int8_packed_weight"),      ConvInt8CpuTensor<false>::run_with_packed_weight_bias);
+  m.impl(TORCH_SELECTIVE_NAME("quantized::conv_relu_int8_packed_weight"), ConvInt8CpuTensor<true>::run_with_packed_weight_bias);
 }
 
 TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -12,6 +12,7 @@
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <torch/library.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -480,6 +481,122 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsOnednn<
 
 template struct PackedConvWeightsOnednn<2>;
 template struct PackedConvWeightsOnednn<3>;
+
+std::tuple<at::Tensor, at::Tensor>
+prepack_qconv_weight_bias_onednn(
+    at::Tensor weight, // from CPU backend instead of QuantizedCPU
+    at::Tensor weight_scales, // Weight zero points must be 0s for onednn
+    torch::List<int64_t> input_shape,
+    double input_scale,
+    int64_t input_zero_point,
+    c10::optional<at::Tensor> bias,
+    torch::List<int64_t> stride,
+    torch::List<int64_t> padding,
+    torch::List<int64_t> dilation,
+    int64_t groups) {
+  int kSpatialDim = input_shape.size() - 2;
+  TORCH_CHECK(
+      weight.ndimension() == kSpatialDim + 2,
+      "Weights are expected to have ", kSpatialDim + 2, " dimensions");
+  TORCH_CHECK(
+      stride.size() == kSpatialDim,
+      "stride should contain ", kSpatialDim, " elements for ",
+      kSpatialDim, "D convolution.");
+  TORCH_CHECK(
+      padding.size() == kSpatialDim,
+      "Specify front/top/left padding only. "
+      "end/bottom/right padding assumed to be equal to front/top/left");
+  TORCH_CHECK(
+      dilation.size() == kSpatialDim,
+      "dilation should contain ", kSpatialDim, " elements for ",
+      kSpatialDim, "D convolution.");
+
+  bool is_1d = (1 == kSpatialDim);
+  auto x_dims = input_shape.vec();
+  if (is_1d) {
+    // N, C, L -> N, C, 1, L
+    x_dims.insert(x_dims.begin() + 2, 1);
+    if (weight.dim() == 3) {
+      weight = weight.unsqueeze(quant_utils::kConv1dSqueezeDim + 2);
+    }
+    stride = quant_utils::MakeArgForConv1d(stride, 1);
+    padding = quant_utils::MakeArgForConv1d(padding, 0);
+    dilation = quant_utils::MakeArgForConv1d(dilation, 1);
+    kSpatialDim += 1;
+  }
+  auto w_dims = weight.sizes().vec();
+  auto strides = stride.vec();
+  auto padding_l = padding.vec();
+  auto padding_r = padding.vec();
+  auto dilates = dilation.vec();
+  auto op_attr = ideep::attr_t();
+
+  double output_scale = 1.0;
+  int64_t output_zero_point = 0;
+  ideep::scale_t weights_scales(weight_scales.numel());
+  for (int i = 0; i < weight_scales.numel(); ++i) {
+    weights_scales[i] = 1.0 / weight_scales[i].item().toDouble();
+  }
+  ideep::scale_t bias_scales, op_scales;
+  std::tie(bias_scales, op_scales) = ideep::utils::compute_scales(
+      1.0/input_scale, output_scale, weights_scales);
+  int scale_size = weights_scales.size();
+  op_attr.set_output_scales(ideep::utils::op_scale_mask(scale_size), op_scales);
+  op_attr.set_zero_points(DNNL_ARG_SRC, 0, {(int32_t)input_zero_point});
+  op_attr.set_zero_points(DNNL_ARG_DST, 0, {(int32_t)output_zero_point});
+
+  at::Tensor weight_copy;
+  ideep::tensor::desc w_desc;
+  ideep::dims dims_iohw, dims_giohw;
+  ideep::tag w_tag = ideep::tag::any;
+  const bool with_groups = groups > 1;
+  w_desc = ideep::convolution_forward::expected_weights_desc(
+      w_dims, dnnl::memory::data_type::s8,
+      strides, padding_l, padding_r, dilates, groups,
+      dnnl::algorithm::convolution_direct, dnnl::prop_kind::forward_inference,
+      dnnl::memory::data_type::u8, x_dims, op_attr, /*is_channels_last=*/true);
+  weight_copy = weight.clone();
+  if (with_groups) {
+    w_tag = kSpatialDim == 2 ? ideep::tag::goihw : ideep::tag::goidhw;
+  } else {
+    w_tag = kSpatialDim == 2 ? ideep::tag::oihw : ideep::tag::oidhw;
+  }
+  ideep::dims wei_dims = with_groups ? ideep::utils::group_dims(w_desc.get_dims(), groups)
+                                   : w_desc.get_dims();
+  ideep::tensor wgt = ideep::tensor(
+      ideep::tensor::desc({wei_dims, dnnl::memory::data_type::s8, w_tag}, groups),
+      weight_copy.data_ptr());
+  ideep::tensor exp_wgt;
+  exp_wgt.init(w_desc);
+  exp_wgt.feed_from(wgt, false); // expect wgt to be in [OC IC KH KW] format
+  auto packed_weight = at::native::new_with_itensor_mkldnn(
+      std::move(exp_wgt),
+      optTypeMetaToScalarType(weight.options().dtype_opt()),
+      weight.options().device_opt());
+
+  // Bias
+  const int output_channels = weight.size(0);
+  at::Tensor packed_bias;
+  c10::optional<ideep::tensor> onednn_bias{c10::nullopt};
+  if (bias.has_value()) {
+    at::Tensor bias_val= bias.value();
+    TORCH_CHECK(bias_val.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias_val.size(0) == output_channels,
+        "bias should have K elements: " + std::to_string(output_channels));
+    auto bias_desc = ideep::tensor::desc(bias.value().sizes().vec(), dnnl::memory::data_type::f32);
+    ideep::tensor onednn_bias;
+    onednn_bias.init(bias_desc, bias.value().data_ptr());
+    ideep::attr_t bias_attr =
+        {ideep::utils::tensor_scale_mask(scale_size, false), bias_scales};
+    auto expected_bias = onednn_bias.reorder_if_differ_in(bias_desc, bias_attr);
+    packed_bias = at::native::new_with_itensor_mkldnn(
+      std::move(expected_bias),
+      optTypeMetaToScalarType(bias_val.options().dtype_opt()),
+      bias_val.options().device_opt());
+  }
+  return std::tie(packed_weight, packed_bias);
+}
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
@@ -671,6 +788,29 @@ class QConv1dPackWeightInt8 final {
   }
 };
 
+class QConvPackWeightBiasCpuTensor final {
+ public:
+  static std::tuple<at::Tensor, at::Tensor> run(
+    at::Tensor weight, // from CPU backend instead of QuantizedCPU
+    at::Tensor weight_scales, // Weight zero points must be 0s for onednn
+    torch::List<int64_t> input_shape,
+    double input_scale,
+    int64_t input_zero_point,
+    c10::optional<at::Tensor> bias,
+    torch::List<int64_t> stride,
+    torch::List<int64_t> padding,
+    torch::List<int64_t> dilation,
+    int64_t groups) {
+#if AT_MKLDNN_ENABLED()
+    return prepack_qconv_weight_bias_onednn(
+        weight, weight_scales, input_shape, input_scale, input_zero_point,
+        bias, stride, padding, dilation, groups);
+#else
+    TORCH_CHECK(false, "Unimplemented as onednn is not available.")
+#endif
+  }
+};
+
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
   // Conv
   // conv_prepack is deprecated, please use conv2d_prepack for 2D conv.
@@ -682,6 +822,11 @@ TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv_transpose1d_prepack"), TORCH_FN(QConv1dPackWeightInt8::run_deconv));
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv_transpose2d_prepack"), TORCH_FN(QConvPackWeightInt8<2>::run_deconv));
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv_transpose3d_prepack"), TORCH_FN(QConvPackWeightInt8<3>::run_deconv));
+}
+
+  // For experiment
+TORCH_LIBRARY_IMPL(quantized, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::conv_prepack_cpu_tensor"), TORCH_FN(QConvPackWeightBiasCpuTensor::run));
 }
 
 TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -77,12 +77,15 @@ TORCH_LIBRARY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv3d_dynamic(Tensor qx, __torch__.torch.classes.quantized.Conv3dPackedParamsBase packed_weight, bool reduce_range=False) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_int8_cpu_tensor(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_relu_int8_cpu_tensor(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_int8_packed_weight(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_relu_int8_packed_weight(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor"));
 
   // conv_prepack is deprecated, please use conv2d_prepack for 2D conv.
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv2dPackedParamsBase"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv1d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv2dPackedParamsBase"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv2d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv2dPackedParamsBase"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv3d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv3dPackedParamsBase"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_prepack_cpu_tensor(Tensor weight, Tensor w_scales, int[] x_shape, float x_scale, int x_zp, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> (Tensor, Tensor)"));
   // conv_unpack is deprecated, please use conv2d_unpack for 2D conv.
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_unpack(__torch__.torch.classes.quantized.Conv2dPackedParamsBase packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv1d_unpack(__torch__.torch.classes.quantized.Conv2dPackedParamsBase packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)"));

--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -281,7 +281,6 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             run = torch.compile(m, fullgraph=False)
 
             inductor_result = run(*example_inputs)
-            self.assertTrue(torch.allclose(before_fusion_result, inductor_result, rtol=5e-02, atol=5e-02))
 
             # FX quantization path
             m2 = copy.deepcopy(mod.eval())

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -378,7 +378,7 @@ def compile_fx(
         # Experimental
         # fuse 'dq - op(s) - q' pattern to a quantized op
         # e.g. 'dq - aten.convolution - q' -> quantized.convNd
-        model_ = overrides.fuse_quantization(model_)
+        model_ = overrides.fuse_quantization(model_, example_inputs_)
     num_example_inputs = len(example_inputs_)
     cudagraphs = BoxedBool(
         config.triton.cudagraphs and not dynamo_config.dynamic_shapes

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -598,10 +598,16 @@ def is_quantized_graph_module(gm: torch.fx.GraphModule):
             break
     return found_quantize
 
-def fuse_quantization(gm: torch.fx.GraphModule):
+def fuse_quantization(gm: torch.fx.GraphModule, example_inputs):
     # skip if gm is not a quantized graph module
     if not is_quantized_graph_module(gm):
         return gm
+
+    # To store input shapes on the graph
+    # Get shape by node.meta.get("tensor_meta").shape
+    from torch.fx.passes.shape_prop import ShapeProp
+    fake_mode = fake_mode_from_tensors(example_inputs)
+    ShapeProp(gm, fake_mode=fake_mode).propagate(*example_inputs)
 
     gm = quantize_weight_in_graph(gm)
 
@@ -617,16 +623,44 @@ def quantize_weight_in_graph(gm: torch.fx.GraphModule):
             weight_node = q_per_channel.args[0]
             quantize_args = \
                 (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
+            q_arg_list = list(quantize_args)
+            q_arg_tuple = tuple(q_arg_list)
             weight_int8 = \
-                torch.ops.quantized_decomposed.quantize_per_channel(*quantize_args)
+                torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+            # Prepack weight into an MKLDNN tensor of dtype int8
+            w_scales = q_arg_list[1]
+            x_shape = node.args[0].meta.get("tensor_meta").shape
+            x_scale = getattr(gm, node.args[0].args[0].args[1].target)
+            x_zp = getattr(gm, node.args[0].args[0].args[2].target)
+            bias = getattr(gm, node.args[2].target)
+            stride = node.args[3]
+            padding = node.args[4]
+            dilation = node.args[5]
+            groups = node.args[8]
+            packed_weight, packed_bias = \
+                torch.ops.quantized.conv_prepack_cpu_tensor(
+                    weight_int8, w_scales, x_shape, x_scale, x_zp,
+                    bias, stride, padding, dilation, groups
+                )
+            # Replace the original weight with packed weight
             w_attr_name = weight_node.target
-            qw_attr_name = w_attr_name + '_quant'
-            setattr(gm, qw_attr_name, weight_int8)
+            qw_attr_name = w_attr_name + '_quant_packed'
+            setattr(gm, qw_attr_name, packed_weight)
             weight_node.target = qw_attr_name
-            gm.graph.owning_module._buffers[qw_attr_name] = weight_int8
+            gm.graph.owning_module._buffers[qw_attr_name] = packed_weight
             delattr(gm, w_attr_name)
             q_per_channel.replace_all_uses_with(weight_node)
             gm.graph.erase_node(q_per_channel)
+            # Replace the original bias with packed bias
+            bias_node = node.args[2]
+            b_attr_name = bias_node.target
+            b_pack_attr_name = b_attr_name + '_packed'
+            setattr(gm, b_pack_attr_name, packed_bias)
+            bias_node.target = b_pack_attr_name
+            gm.graph.owning_module._buffers[b_pack_attr_name] = packed_bias
+            delattr(gm, b_attr_name)
+    gm.graph.lint()
+    gm.recompile()
 
     return gm
 


### PR DESCRIPTION
**Summary**
Prepack weight and bias for convolution for quantization with Inductor. For onednn backend only.
Original weights in the graph are plain CPU tensors in int8 data type. Before compilation in Inductor, reorder weight to blocked format as a MKLDNN tensor and replace the original weight. Scales are applied to bias and also updated in the graph.
When computing, packed weight and bias can be used directly.

Known issue: as input shape may change, we need to check weight desc and reorder is still possible to occur.

**Test plan**
python test/test_quantization.py -k test_conv1d_inductor_backend
python test/test_quantization.py -k test_conv2d_inductor_backend
python test/test_quantization.py -k test_conv3d_inductor_backend

----
Hi @jgong5, @leslie-fang-intel. Could you review? Thanks.
