### PR TITLE
[Quant][Inductor] Prepack weight and bias for linear

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -901,6 +901,102 @@ at::Tensor PackedLinearWeightsOnednn:: apply_tanh(
       std::move(input), output_scale, output_zero_point);
 }
 
+template <bool kReluFused>
+static at::Tensor onednn_linear_int8_with_prepacked_weight_bias(
+    at::Tensor input, // contains quantized values but not QTensor
+    double input_scale,
+    int64_t input_zero_point,
+    at::Tensor weight, // MKLDNN tensor with quantized values
+    at::Tensor weight_scales,
+    at::Tensor weight_zero_points,
+    c10::optional<at::Tensor> bias, // Bias is packed if not None
+    double output_scale,
+    int64_t output_zero_point) {
+  const int64_t dim = input.dim();
+  TORCH_CHECK(
+      dim != 0,
+      "qlinear (ONEDNN): input dim should be at least 1, but got 0");
+  TORCH_CHECK(input.scalar_type() == c10::ScalarType::Byte,
+      "qlinear (ONEDNN): data type of input should be uint8 (unsigned char).");
+  TORCH_CHECK(weight.scalar_type() == c10::ScalarType::Char,
+      "qlinear (ONEDNN): data type of input should be int8 (char).");
+
+  /*********************************/
+  /*          Prepare              */
+  /*********************************/
+  // Parameters
+  // Scales of ONEDNN and PyTorch are reciprocal
+  const ideep::scale_t& src_scales = ideep::scale_t(1, 1.0 / input_scale);
+  double inv_output_scale = 1.0 / output_scale;
+  const ideep::scale_t& dst_scales = ideep::scale_t(1, inv_output_scale);
+  ideep::scale_t weights_scales(weight_scales.numel());
+  for (int i = 0; i < weight_scales.numel(); ++i) {
+    weights_scales[i] = 1.0 / weight_scales[i].item().toDouble();
+  }
+  const ideep::zero_point_t src_zero_points = ideep::zero_point_t(1, input_zero_point);
+  const ideep::zero_point_t dst_zero_points = ideep::zero_point_t(1, output_zero_point);
+
+  // Weight
+  auto packed_weight = at::native::itensor_from_mkldnn(weight);
+  // Here we check weight desc and reorder weight if necessary
+  // because input shape may change and so does weight layout
+  auto op_attr = ideep::attr_t();
+  ideep::scale_t bias_scales, op_scales;
+  std::tie(bias_scales, op_scales) = ideep::utils::compute_scales(
+      src_scales[0], dst_scales[0], weights_scales);
+  int scale_size = weights_scales.size();
+  op_attr.set_output_scales(ideep::utils::op_scale_mask(scale_size), op_scales);
+  op_attr.set_zero_points(DNNL_ARG_SRC, 0, src_zero_points);
+  op_attr.set_zero_points(DNNL_ARG_DST, 0, dst_zero_points);
+  auto w_desc = ideep::matmul_forward::expected_weights_desc(
+      weight.sizes().vec(), dnnl::memory::data_type::s8, dnnl::memory::data_type::u8);
+  ideep::tensor expected_weight = packed_weight.reorder_if_differ_in(w_desc);
+
+  // Bias
+  c10::optional<ideep::tensor> onednn_bias{c10::nullopt};
+  bool with_bias = bias.has_value();
+  if (with_bias) {
+    onednn_bias = at::native::itensor_from_mkldnn(bias.value());
+  }
+  const auto& expected_bias = with_bias ? onednn_bias.value() : ideep::tensor();
+
+  /*********************************/
+  /*        Computation            */
+  /*********************************/
+  auto input_contig = input.expect_contiguous();
+  auto K = input.size(dim - 1), M = input.numel() / K, N = expected_weight.get_dim(1);
+  auto input_dims = {M, K};
+  auto input_data_type = dnnl::memory::data_type::u8;
+  auto input_desc = ideep::tensor::desc(input_dims, input_data_type);
+  op_attr = ideep::attr_t();
+  if (kReluFused) {
+    op_attr = ideep::attr_t::fuse_relu();
+  }
+  ideep::tensor x(input_desc, input_contig->data_ptr());
+  auto dst_dims = {M, N};
+  // Allocate output Tensor
+  // Output is not a quantized tensor but data type is uint8
+  at::Tensor output = at::empty(
+    dst_dims,
+    device(c10::kCPU)
+        .dtype(c10::kByte)
+  );
+  if (output.numel() == 0) {
+    return output;
+  }
+  ideep::tensor y({dst_dims, ideep::tensor::data_type::u8,
+                   {output.strides().cbegin(), output.strides().cend()}},
+                  output.data_ptr());
+  ideep::matmul_forward::compute<true, false>(
+      x, expected_weight, expected_bias, y,
+      src_scales, weights_scales, dst_scales,
+      src_zero_points, dst_zero_points, 1.0f, 1.0f, op_attr);
+  auto out_sizes = input.sizes().vec();
+  out_sizes.back() = N;
+  if (output.sizes().vec() == out_sizes)
+    return output;
+  return output.reshape(out_sizes);
+}
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
@@ -987,6 +1083,30 @@ class QLinearInt8FusedQDQ final {
   }
 };
 
+template <bool kReluFused>
+class LinearInt8CpuTensor final {
+ public:
+  static Tensor run_with_packed_weight_bias(
+      Tensor act, // CPU tensor with quantized values
+      double act_scale,
+      int64_t act_zero_point,
+      Tensor weight, // MkldnnCPU tensor with quantized values
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      c10::optional<Tensor> bias,
+      double output_scale,
+      int64_t output_zero_point) {
+#if AT_MKLDNN_ENABLED()
+    return onednn_linear_int8_with_prepacked_weight_bias<kReluFused>(
+        act, act_scale, act_zero_point,
+        weight, weight_scales, weight_zero_points,
+        bias, output_scale, output_zero_point
+    );
+#endif
+    TORCH_CHECK(false, "Unimplemented (int8 linear with packed weight and bias)");
+  }
+};
+
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
   register_linear_params();
   m.impl(TORCH_SELECTIVE_NAME("quantized::linear"), TORCH_FN(QLinearInt8<false>::run));
@@ -1003,6 +1123,11 @@ TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
 TORCH_LIBRARY_IMPL(quantized, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("quantized::linear_with_input_q_dq_qweight_dq_output_fp32"), TORCH_FN(QLinearInt8FusedQDQ<false>::run));
   m.impl(TORCH_SELECTIVE_NAME("quantized::linear_with_input_q_dq_qweight_dq_relu_output_fp32"), TORCH_FN(QLinearInt8FusedQDQ<true>::run));
+}
+
+TORCH_LIBRARY_IMPL(quantized, MkldnnCPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_int8_packed_weight"),      LinearInt8CpuTensor<false>::run_with_packed_weight_bias);
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_relu_int8_packed_weight"), LinearInt8CpuTensor<true>::run_with_packed_weight_bias);
 }
 
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -278,6 +278,74 @@ c10::intrusive_ptr<LinearPackedParamsBase> PackedLinearWeightsOnednn::prepack(
         bias});
   return ret_ptr;
 }
+
+std::tuple<at::Tensor, at::Tensor>
+prepack_qlinear_weight_bias_onednn(
+    at::Tensor weight, // from CPU backend instead of QuantizedCPU
+    at::Tensor weight_scales, // Weight zero points must be 0s for onednn
+    torch::List<int64_t> input_shape,
+    double input_scale,
+    int64_t input_zero_point,
+    c10::optional<at::Tensor> bias) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "Prepack qlinear weight: Expected 2-dimensional weight tensor.");
+  // Weight
+  std::vector<int64_t> w_dims = weight.sizes().vec();
+  auto x_dims = input_shape.vec();
+  auto op_attr = ideep::attr_t();
+
+  // Do not need real output scale/zero point for weight packing
+  double output_scale = 1.0;
+  int64_t output_zero_point = 0;
+  ideep::scale_t weights_scales(weight_scales.numel());
+  for (int i = 0; i < weight_scales.numel(); ++i) {
+    weights_scales[i] = 1.0 / weight_scales[i].item().toDouble();
+  }
+  ideep::scale_t bias_scales, op_scales;
+  std::tie(bias_scales, op_scales) = ideep::utils::compute_scales(
+      1.0/input_scale, output_scale, weights_scales);
+  int scale_size = weights_scales.size();
+  op_attr.set_output_scales(ideep::utils::op_scale_mask(scale_size), op_scales);
+  op_attr.set_zero_points(DNNL_ARG_SRC, 0, {(int32_t)input_zero_point});
+  op_attr.set_zero_points(DNNL_ARG_DST, 0, {(int32_t)output_zero_point});
+
+  // Prepack weight
+  auto weight_copy = weight.clone();
+  ideep::tensor wgt = ideep::tensor({w_dims, dnnl::memory::data_type::s8}, weight_copy.data_ptr());
+  wgt.transpose_(0, 1); // ONEDNN requires transposed weight
+  auto w_desc = ideep::matmul_forward::expected_weights_desc(wgt.get_dims(), dnnl::memory::data_type::s8,
+                                                             dnnl::memory::data_type::u8);
+  wgt = wgt.reorder_if_differ_in(w_desc);
+  auto packed_weight = at::native::new_with_itensor_mkldnn(
+      std::move(wgt),
+      optTypeMetaToScalarType(weight.options().dtype_opt()),
+      weight.options().device_opt());
+
+  // Bias
+  at::Tensor packed_bias;
+  if (bias.has_value()) {
+    auto& b = bias.value();
+    auto bias_size = b.sizes().vec();
+    bias_size.insert(bias_size.begin(), 1);
+    TORCH_CHECK(
+        bias_size[1] == packed_weight.size(1),
+        "bias should have N elements: ",
+        std::to_string(packed_weight.size(1)),
+        ", but got ", bias_size[1]);
+    auto bias_desc = ideep::tensor::desc(bias_size, dnnl::memory::data_type::f32);
+    ideep::tensor onednn_bias;
+    onednn_bias.init(bias_desc, b.data_ptr());
+    int mask = scale_size > 1 ? 1 << (onednn_bias.ndims() - 1) : 0;
+    ideep::attr_t bias_attr = {mask, bias_scales};
+    auto expected_bias = onednn_bias.reorder_if_differ_in(bias_desc, bias_attr);
+    packed_bias = at::native::new_with_itensor_mkldnn(
+      std::move(expected_bias),
+      optTypeMetaToScalarType(b.options().dtype_opt()),
+      b.options().device_opt());
+  }
+  return std::tie(packed_weight, packed_bias);
+}
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
@@ -380,6 +448,24 @@ class QLinearPackWeightFp16Legacy final {
   }
 };
 
+class QLinearPackWeightBiasInt8CpuTensor final {
+ public:
+  static std::tuple<at::Tensor, at::Tensor> run(
+    at::Tensor weight, // from CPU backend instead of QuantizedCPU
+    at::Tensor weight_scales, // Weight zero points must be 0s for onednn
+    torch::List<int64_t> input_shape,
+    double input_scale,
+    int64_t input_zero_point,
+    c10::optional<at::Tensor> bias) {
+#if AT_MKLDNN_ENABLED()
+    return prepack_qlinear_weight_bias_onednn(
+        weight, weight_scales, input_shape, input_scale, input_zero_point, bias);
+#else
+    TORCH_CHECK(false, "Unimplemented as onednn is not available.");
+#endif
+  }
+};
+
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
   register_linear_params();
   m.impl(TORCH_SELECTIVE_NAME("quantized::linear_prepack"), TORCH_FN(QLinearPackWeightInt8::run));
@@ -401,6 +487,11 @@ TORCH_LIBRARY_IMPL(_quantized, CPU, m) {
   register_linear_params();
   m.impl(TORCH_SELECTIVE_NAME("_quantized::linear_prepack_fp16"), TORCH_FN(QLinearPackWeightFp16::run));
   m.impl(TORCH_SELECTIVE_NAME("_quantized::linear_prepack_fp16_legacy"), TORCH_FN(QLinearPackWeightFp16Legacy::run));
+}
+
+  // For experiment
+TORCH_LIBRARY_IMPL(quantized, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_prepack_cpu_tensor"), TORCH_FN(QLinearPackWeightBiasInt8CpuTensor::run));
 }
 
 } // namespace

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -193,10 +193,13 @@ TORCH_LIBRARY(quantized, m) {
   // Returns:
   //    Y: float32 Tensor
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_with_input_q_dq_qweight_dq_relu_output_fp32(Tensor X, float X_scale, int X_zero_point, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_int8_packed_weight(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, float output_scale, int output_zero_point) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_relu_int8_packed_weight(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, float output_scale, int output_zero_point) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack(Tensor W, Tensor? B=None) -> __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack_fp16(Tensor W, Tensor? B=None) -> __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack_legacy(Tensor W, Tensor? B=None) -> Tensor W_prepack"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack_fp16_legacy(Tensor W, Tensor? B=None) -> Tensor W_prepack"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack_cpu_tensor(Tensor weight, Tensor w_scales, int[] x_shape, float x_scale, int x_zp, Tensor? bias) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack(__torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack_fp16(__torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack.legacy(Tensor W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));

--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -282,14 +282,13 @@ class TestQuantizePT2EModels(QuantizationTestCase):
     def _test_inductor_backend_helper(self, mod: torch.nn.Module, input_shape: tuple):
         import copy
         from torch import _dynamo, _inductor
-        from torch._inductor import config
         import logging
         from torch.ao.quantization import get_default_qconfig_mapping
 
-        torch._dynamo.config.log_level = logging.DEBUG
-        torch._dynamo.config.verbose = True
-        torch._inductor.config.trace.enabled = True
-        torch._inductor.config.debug = True
+        _dynamo.config.log_level = logging.DEBUG
+        _dynamo.config.verbose = True
+        _inductor.config.trace.enabled = True
+        _inductor.config.debug = True
 
         # Found some weird accuracy issue, especially with x86 backend.
         # Maybe because x86 uses reduced range, range of uint8 is 0-127.

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -615,7 +615,31 @@ def fuse_quantization(gm: torch.fx.GraphModule, example_inputs):
 
     return gm
 
-def prepack_weight_in_graph(gm: torch.fx.GraphModule):
+def _insert_packed_weight_bias(
+        gm: torch.fx.GraphModule,
+        weight_node: torch.fx.Node,
+        bias_node: torch.fx.Node,
+        q_per_channel_node: torch.fx.Node,
+        packed_weight: torch.Tensor,
+        packed_bias: torch.Tensor):
+    w_attr_name = weight_node.target
+    qw_attr_name = w_attr_name + '_quant_packed'
+    setattr(gm, qw_attr_name, packed_weight)
+    weight_node.target = qw_attr_name
+    gm.graph.owning_module._buffers[qw_attr_name] = packed_weight
+    delattr(gm, w_attr_name)
+    q_per_channel_node.replace_all_uses_with(weight_node)
+    gm.graph.erase_node(q_per_channel_node)
+    # Replace the original bias with packed bias
+    if bias_node is not None:
+        b_attr_name = bias_node.target
+        b_pack_attr_name = b_attr_name + '_packed'
+        setattr(gm, b_pack_attr_name, packed_bias)
+        bias_node.target = b_pack_attr_name
+        gm.graph.owning_module._buffers[b_pack_attr_name] = packed_bias
+        delattr(gm, b_attr_name)
+
+def _prepack_conv_weight(gm: torch.fx.GraphModule):
     for node in gm.graph.nodes:
         if node.target == torch.ops.aten.convolution.default:
             dq_per_channel = node.args[1]
@@ -644,25 +668,62 @@ def prepack_weight_in_graph(gm: torch.fx.GraphModule):
                     bias, stride, padding, dilation, groups
                 )
             # Replace the original weight with packed weight
-            w_attr_name = weight_node.target
-            qw_attr_name = w_attr_name + '_quant_packed'
-            setattr(gm, qw_attr_name, packed_weight)
-            weight_node.target = qw_attr_name
-            gm.graph.owning_module._buffers[qw_attr_name] = packed_weight
-            delattr(gm, w_attr_name)
-            q_per_channel.replace_all_uses_with(weight_node)
-            gm.graph.erase_node(q_per_channel)
-            # Replace the original bias with packed bias
-            if bias_node is not None:
-                b_attr_name = bias_node.target
-                b_pack_attr_name = b_attr_name + '_packed'
-                setattr(gm, b_pack_attr_name, packed_bias)
-                bias_node.target = b_pack_attr_name
-                gm.graph.owning_module._buffers[b_pack_attr_name] = packed_bias
-                delattr(gm, b_attr_name)
+            _insert_packed_weight_bias(
+                gm, weight_node, bias_node, q_per_channel, packed_weight, packed_bias
+            )
     gm.graph.lint()
     gm.recompile()
 
+    return gm
+
+def _prepack_linear_weight(gm: torch.fx.GraphModule):
+    """
+    Linear is decomposed to `t - addmm` (w/ bias) or `t - mm` (w/o bias)
+    To find the pattern:
+         weight - observer - t \
+         input - observer - addmm/mm
+    """
+    aten = torch.ops.aten
+    for node in gm.graph.nodes:
+        if node.target in (aten.addmm.default, aten.mm.default):
+            with_bias = (node.target == aten.addmm.default)
+            t_node = node.args[-1]
+            if t_node.target != aten.t.default:
+                continue
+            dq_per_channel = t_node.args[0]
+            if dq_per_channel.target != torch.ops.quantized_decomposed.dequantize_per_channel:
+                continue
+            q_per_channel = dq_per_channel.args[0]
+            weight_node = q_per_channel.args[0]
+            bias_node = node.args[0] if with_bias else None
+            quantize_args = \
+                (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
+            q_arg_list = list(quantize_args)
+            q_arg_tuple = tuple(q_arg_list)
+            weight_int8 = \
+                torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+            # Prepack weight into an MKLDNN tensor of dtype int8
+            w_scales = q_arg_list[1]
+            x_shape = node.args[-2].meta.get("tensor_meta").shape
+            x_scale = getattr(gm, node.args[-2].args[0].args[1].target)
+            x_zp = getattr(gm, node.args[-2].args[0].args[2].target)
+            bias = getattr(gm, bias_node.target) if bias_node is not None else None
+            packed_weight, packed_bias = \
+                torch.ops.quantized.linear_prepack_cpu_tensor(
+                    weight_int8, w_scales, x_shape, x_scale, x_zp, bias
+                )
+            # Replace the original weight with packed weight
+            _insert_packed_weight_bias(
+                gm, weight_node, bias_node, q_per_channel, packed_weight, packed_bias
+            )
+    gm.graph.lint()
+    gm.recompile()
+
+    return gm
+
+def prepack_weight_in_graph(gm: torch.fx.GraphModule):
+    gm = _prepack_conv_weight(gm)
+    gm = _prepack_linear_weight(gm)
     return gm
 
 def fuse_reference_quantized_conv(gm: torch.fx.GraphModule):

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -251,14 +251,13 @@ quantized_decomposed_lib.define(
     "Tensor output_scale, Tensor output_zero_point, str unary_post_op) -> Tensor")
 
 @impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "CPU")
-def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
-                          bias, output_scale, output_zero_point, unary_post_op):
+def linear_unary_cpu(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
+                     bias, output_scale, output_zero_point, unary_post_op):
     quantized = torch.ops.quantized
 
     qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
     qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
     w_packed = quantized.linear_prepack(qw, bias)
-    
 
     if unary_post_op == 'relu':
         return quantized.linear_relu(qx, w_packed, output_scale, output_zero_point)
@@ -266,27 +265,29 @@ def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
     return quantized.linear(qx, w_packed, output_scale, output_zero_point)
 
 @impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "MkldnnCPU")
-def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
-                          bias, output_scale, output_zero_point, unary_post_op):
+def linear_unary_mkldnn_cpu(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
+                            bias, output_scale, output_zero_point, unary_post_op):
     quantized = torch.ops.quantized
 
-    qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
-    qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
-    w_packed = quantized.linear_prepack(qw, bias)
-    
-
     if unary_post_op == 'relu':
-        return quantized.linear(qx, w_packed, output_scale, output_zero_point)
+        return quantized.linear_relu_int8_packed_weight(
+            qx, x_scale, x_zp, qw, w_scale, w_zp, bias, output_scale, output_zero_point
+        )
     # Last case: unary_post_op = 'None'
-    return quantized.linear_relu(qx, w_packed, output_scale, output_zero_point)
+    return quantized.linear_int8_packed_weight(
+        qx, x_scale, x_zp, qw, w_scale, w_zp, bias, output_scale, output_zero_point
+    )
 
 @impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "Meta")
-def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
-                          output_scale, output_zero_point, unary_post_op):
-    # Shapes:
+def linear_unary_meta(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
+                      output_scale, output_zero_point, unary_post_op):
+    # Original shapes:
     # qx = [BS, IC], qw = [OC, IC], out = [BS, OC]
+    # After weight prepacking:
+    # qx = [BS, IC], qw = [IC, OC], out = [BS, OC]
+    # Assume weight is prepacked
     shape_out = list(qx.shape)
-    shape_out[-1] = qw.shape[-2]
+    shape_out[-1] = qw.shape[-1]
     out_format = torch.contiguous_format
     out = qx.new_empty(tuple(shape_out))
     out = out.to(memory_format=out_format)


### PR DESCRIPTION
**Summary**
This is part of Inductor quantization PoC .
Prepack weight and bias for linear. Replace original weight and bias with packed ones on the graph.
Similar implementation as convolution.

**Test plan**
python test/test_quantization.py -k test_linear_inductor_backend

---

@jgong5 @leslie-fang-intel Could you review? Thanks.