### PR TITLE
[Quant][Inductor] Prepack weight for conv and linear after quantization fusion

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -12,6 +12,7 @@
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <torch/library.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -480,6 +481,122 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsOnednn<
 
 template struct PackedConvWeightsOnednn<2>;
 template struct PackedConvWeightsOnednn<3>;
+
+std::tuple<at::Tensor, at::Tensor>
+prepack_qconv_weight_bias_onednn(
+    at::Tensor weight, // from CPU backend instead of QuantizedCPU
+    at::Tensor weight_scales, // Weight zero points must be 0s for onednn
+    torch::List<int64_t> input_shape,
+    double input_scale,
+    int64_t input_zero_point,
+    c10::optional<at::Tensor> bias,
+    torch::List<int64_t> stride,
+    torch::List<int64_t> padding,
+    torch::List<int64_t> dilation,
+    int64_t groups) {
+  int kSpatialDim = input_shape.size() - 2;
+  TORCH_CHECK(
+      weight.ndimension() == kSpatialDim + 2,
+      "Weights are expected to have ", kSpatialDim + 2, " dimensions");
+  TORCH_CHECK(
+      stride.size() == kSpatialDim,
+      "stride should contain ", kSpatialDim, " elements for ",
+      kSpatialDim, "D convolution.");
+  TORCH_CHECK(
+      padding.size() == kSpatialDim,
+      "Specify front/top/left padding only. "
+      "end/bottom/right padding assumed to be equal to front/top/left");
+  TORCH_CHECK(
+      dilation.size() == kSpatialDim,
+      "dilation should contain ", kSpatialDim, " elements for ",
+      kSpatialDim, "D convolution.");
+
+  bool is_1d = (1 == kSpatialDim);
+  auto x_dims = input_shape.vec();
+  if (is_1d) {
+    // N, C, L -> N, C, 1, L
+    x_dims.insert(x_dims.begin() + 2, 1);
+    if (weight.dim() == 3) {
+      weight = weight.unsqueeze(quant_utils::kConv1dSqueezeDim + 2);
+    }
+    stride = quant_utils::MakeArgForConv1d(stride, 1);
+    padding = quant_utils::MakeArgForConv1d(padding, 0);
+    dilation = quant_utils::MakeArgForConv1d(dilation, 1);
+    kSpatialDim += 1;
+  }
+  auto w_dims = weight.sizes().vec();
+  auto strides = stride.vec();
+  auto padding_l = padding.vec();
+  auto padding_r = padding.vec();
+  auto dilates = dilation.vec();
+  auto op_attr = ideep::attr_t();
+
+  double output_scale = 1.0;
+  int64_t output_zero_point = 0;
+  ideep::scale_t weights_scales(weight_scales.numel());
+  for (int i = 0; i < weight_scales.numel(); ++i) {
+    weights_scales[i] = 1.0 / weight_scales[i].item().toDouble();
+  }
+  ideep::scale_t bias_scales, op_scales;
+  std::tie(bias_scales, op_scales) = ideep::utils::compute_scales(
+      1.0/input_scale, output_scale, weights_scales);
+  int scale_size = weights_scales.size();
+  op_attr.set_output_scales(ideep::utils::op_scale_mask(scale_size), op_scales);
+  op_attr.set_zero_points(DNNL_ARG_SRC, 0, {(int32_t)input_zero_point});
+  op_attr.set_zero_points(DNNL_ARG_DST, 0, {(int32_t)output_zero_point});
+
+  at::Tensor weight_copy;
+  ideep::tensor::desc w_desc;
+  ideep::dims dims_iohw, dims_giohw;
+  ideep::tag w_tag = ideep::tag::any;
+  const bool with_groups = groups > 1;
+  w_desc = ideep::convolution_forward::expected_weights_desc(
+      w_dims, dnnl::memory::data_type::s8,
+      strides, padding_l, padding_r, dilates, groups,
+      dnnl::algorithm::convolution_direct, dnnl::prop_kind::forward_inference,
+      dnnl::memory::data_type::u8, x_dims, op_attr, /*is_channels_last=*/true);
+  weight_copy = weight.clone();
+  if (with_groups) {
+    w_tag = kSpatialDim == 2 ? ideep::tag::goihw : ideep::tag::goidhw;
+  } else {
+    w_tag = kSpatialDim == 2 ? ideep::tag::oihw : ideep::tag::oidhw;
+  }
+  ideep::dims wei_dims = with_groups ? ideep::utils::group_dims(w_desc.get_dims(), groups)
+                                   : w_desc.get_dims();
+  ideep::tensor wgt = ideep::tensor(
+      ideep::tensor::desc({wei_dims, dnnl::memory::data_type::s8, w_tag}, groups),
+      weight_copy.data_ptr());
+  ideep::tensor exp_wgt;
+  exp_wgt.init(w_desc);
+  exp_wgt.feed_from(wgt, false); // expect wgt to be in [OC IC KH KW] format
+  auto packed_weight = at::native::new_with_itensor_mkldnn(
+      std::move(exp_wgt),
+      optTypeMetaToScalarType(weight.options().dtype_opt()),
+      weight.options().device_opt());
+
+  // Bias
+  const int output_channels = weight.size(0);
+  at::Tensor packed_bias;
+  c10::optional<ideep::tensor> onednn_bias{c10::nullopt};
+  if (bias.has_value()) {
+    at::Tensor bias_val= bias.value();
+    TORCH_CHECK(bias_val.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias_val.size(0) == output_channels,
+        "bias should have K elements: " + std::to_string(output_channels));
+    auto bias_desc = ideep::tensor::desc(bias.value().sizes().vec(), dnnl::memory::data_type::f32);
+    ideep::tensor onednn_bias;
+    onednn_bias.init(bias_desc, bias.value().data_ptr());
+    ideep::attr_t bias_attr =
+        {ideep::utils::tensor_scale_mask(scale_size, false), bias_scales};
+    auto expected_bias = onednn_bias.reorder_if_differ_in(bias_desc, bias_attr);
+    packed_bias = at::native::new_with_itensor_mkldnn(
+      std::move(expected_bias),
+      optTypeMetaToScalarType(bias_val.options().dtype_opt()),
+      bias_val.options().device_opt());
+  }
+  return std::tie(packed_weight, packed_bias);
+}
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
@@ -671,6 +788,29 @@ class QConv1dPackWeightInt8 final {
   }
 };
 
+class QConvPackWeightBiasCpuTensor final {
+ public:
+  static std::tuple<at::Tensor, at::Tensor> run(
+    at::Tensor weight, // from CPU backend instead of QuantizedCPU
+    at::Tensor weight_scales, // Weight zero points must be 0s for onednn
+    torch::List<int64_t> input_shape,
+    double input_scale,
+    int64_t input_zero_point,
+    c10::optional<at::Tensor> bias,
+    torch::List<int64_t> stride,
+    torch::List<int64_t> padding,
+    torch::List<int64_t> dilation,
+    int64_t groups) {
+#if AT_MKLDNN_ENABLED()
+    return prepack_qconv_weight_bias_onednn(
+        weight, weight_scales, input_shape, input_scale, input_zero_point,
+        bias, stride, padding, dilation, groups);
+#else
+    TORCH_CHECK(false, "Unimplemented as onednn is not available.")
+#endif
+  }
+};
+
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
   // Conv
   // conv_prepack is deprecated, please use conv2d_prepack for 2D conv.
@@ -682,6 +822,11 @@ TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv_transpose1d_prepack"), TORCH_FN(QConv1dPackWeightInt8::run_deconv));
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv_transpose2d_prepack"), TORCH_FN(QConvPackWeightInt8<2>::run_deconv));
   m.impl(TORCH_SELECTIVE_NAME("quantized::conv_transpose3d_prepack"), TORCH_FN(QConvPackWeightInt8<3>::run_deconv));
+}
+
+  // For experiment
+TORCH_LIBRARY_IMPL(quantized, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::conv_prepack_cpu_tensor"), TORCH_FN(QConvPackWeightBiasCpuTensor::run));
 }
 
 TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -901,6 +901,102 @@ at::Tensor PackedLinearWeightsOnednn:: apply_tanh(
       std::move(input), output_scale, output_zero_point);
 }
 
+template <bool kReluFused>
+static at::Tensor onednn_linear_int8_with_prepacked_weight_bias(
+    at::Tensor input, // contains quantized values but not QTensor
+    double input_scale,
+    int64_t input_zero_point,
+    at::Tensor weight, // MKLDNN tensor with quantized values
+    at::Tensor weight_scales,
+    at::Tensor weight_zero_points,
+    c10::optional<at::Tensor> bias, // Bias is packed if not None
+    double output_scale,
+    int64_t output_zero_point) {
+  const int64_t dim = input.dim();
+  TORCH_CHECK(
+      dim != 0,
+      "qlinear (ONEDNN): input dim should be at least 1, but got 0");
+  TORCH_CHECK(input.scalar_type() == c10::ScalarType::Byte,
+      "qlinear (ONEDNN): data type of input should be uint8 (unsigned char).");
+  TORCH_CHECK(weight.scalar_type() == c10::ScalarType::Char,
+      "qlinear (ONEDNN): data type of input should be int8 (char).");
+
+  /*********************************/
+  /*          Prepare              */
+  /*********************************/
+  // Parameters
+  // Scales of ONEDNN and PyTorch are reciprocal
+  const ideep::scale_t& src_scales = ideep::scale_t(1, 1.0 / input_scale);
+  double inv_output_scale = 1.0 / output_scale;
+  const ideep::scale_t& dst_scales = ideep::scale_t(1, inv_output_scale);
+  ideep::scale_t weights_scales(weight_scales.numel());
+  for (int i = 0; i < weight_scales.numel(); ++i) {
+    weights_scales[i] = 1.0 / weight_scales[i].item().toDouble();
+  }
+  const ideep::zero_point_t src_zero_points = ideep::zero_point_t(1, input_zero_point);
+  const ideep::zero_point_t dst_zero_points = ideep::zero_point_t(1, output_zero_point);
+
+  // Weight
+  auto packed_weight = at::native::itensor_from_mkldnn(weight);
+  // Here we check weight desc and reorder weight if necessary
+  // because input shape may change and so does weight layout
+  auto op_attr = ideep::attr_t();
+  ideep::scale_t bias_scales, op_scales;
+  std::tie(bias_scales, op_scales) = ideep::utils::compute_scales(
+      src_scales[0], dst_scales[0], weights_scales);
+  int scale_size = weights_scales.size();
+  op_attr.set_output_scales(ideep::utils::op_scale_mask(scale_size), op_scales);
+  op_attr.set_zero_points(DNNL_ARG_SRC, 0, src_zero_points);
+  op_attr.set_zero_points(DNNL_ARG_DST, 0, dst_zero_points);
+  auto w_desc = ideep::matmul_forward::expected_weights_desc(
+      weight.sizes().vec(), dnnl::memory::data_type::s8, dnnl::memory::data_type::u8);
+  ideep::tensor expected_weight = packed_weight.reorder_if_differ_in(w_desc);
+
+  // Bias
+  c10::optional<ideep::tensor> onednn_bias{c10::nullopt};
+  bool with_bias = bias.has_value();
+  if (with_bias) {
+    onednn_bias = at::native::itensor_from_mkldnn(bias.value());
+  }
+  const auto& expected_bias = with_bias ? onednn_bias.value() : ideep::tensor();
+
+  /*********************************/
+  /*        Computation            */
+  /*********************************/
+  auto input_contig = input.expect_contiguous();
+  auto K = input.size(dim - 1), M = input.numel() / K, N = expected_weight.get_dim(1);
+  auto input_dims = {M, K};
+  auto input_data_type = dnnl::memory::data_type::u8;
+  auto input_desc = ideep::tensor::desc(input_dims, input_data_type);
+  op_attr = ideep::attr_t();
+  if (kReluFused) {
+    op_attr = ideep::attr_t::fuse_relu();
+  }
+  ideep::tensor x(input_desc, input_contig->data_ptr());
+  auto dst_dims = {M, N};
+  // Allocate output Tensor
+  // Output is not a quantized tensor but data type is uint8
+  at::Tensor output = at::empty(
+    dst_dims,
+    device(c10::kCPU)
+        .dtype(c10::kByte)
+  );
+  if (output.numel() == 0) {
+    return output;
+  }
+  ideep::tensor y({dst_dims, ideep::tensor::data_type::u8,
+                   {output.strides().cbegin(), output.strides().cend()}},
+                  output.data_ptr());
+  ideep::matmul_forward::compute<true, false>(
+      x, expected_weight, expected_bias, y,
+      src_scales, weights_scales, dst_scales,
+      src_zero_points, dst_zero_points, 1.0f, 1.0f, op_attr);
+  auto out_sizes = input.sizes().vec();
+  out_sizes.back() = N;
+  if (output.sizes().vec() == out_sizes)
+    return output;
+  return output.reshape(out_sizes);
+}
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
@@ -987,6 +1083,30 @@ class QLinearInt8FusedQDQ final {
   }
 };
 
+template <bool kReluFused>
+class LinearInt8CpuTensor final {
+ public:
+  static Tensor run_with_packed_weight_bias(
+      Tensor act, // CPU tensor with quantized values
+      double act_scale,
+      int64_t act_zero_point,
+      Tensor weight, // MkldnnCPU tensor with quantized values
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      c10::optional<Tensor> bias,
+      double output_scale,
+      int64_t output_zero_point) {
+#if AT_MKLDNN_ENABLED()
+    return onednn_linear_int8_with_prepacked_weight_bias<kReluFused>(
+        act, act_scale, act_zero_point,
+        weight, weight_scales, weight_zero_points,
+        bias, output_scale, output_zero_point
+    );
+#endif
+    TORCH_CHECK(false, "Unimplemented (int8 linear with packed weight and bias)");
+  }
+};
+
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
   register_linear_params();
   m.impl(TORCH_SELECTIVE_NAME("quantized::linear"), TORCH_FN(QLinearInt8<false>::run));
@@ -1003,6 +1123,11 @@ TORCH_LIBRARY_IMPL(_quantized, QuantizedCPU, m) {
 TORCH_LIBRARY_IMPL(quantized, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("quantized::linear_with_input_q_dq_qweight_dq_output_fp32"), TORCH_FN(QLinearInt8FusedQDQ<false>::run));
   m.impl(TORCH_SELECTIVE_NAME("quantized::linear_with_input_q_dq_qweight_dq_relu_output_fp32"), TORCH_FN(QLinearInt8FusedQDQ<true>::run));
+}
+
+TORCH_LIBRARY_IMPL(quantized, MkldnnCPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_int8_packed_weight"),      LinearInt8CpuTensor<false>::run_with_packed_weight_bias);
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_relu_int8_packed_weight"), LinearInt8CpuTensor<true>::run_with_packed_weight_bias);
 }
 
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/quantized/cpu/XnnpackUtils.h>
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/library.h>
 

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -278,6 +278,74 @@ c10::intrusive_ptr<LinearPackedParamsBase> PackedLinearWeightsOnednn::prepack(
         bias});
   return ret_ptr;
 }
+
+std::tuple<at::Tensor, at::Tensor>
+prepack_qlinear_weight_bias_onednn(
+    at::Tensor weight, // from CPU backend instead of QuantizedCPU
+    at::Tensor weight_scales, // Weight zero points must be 0s for onednn
+    torch::List<int64_t> input_shape,
+    double input_scale,
+    int64_t input_zero_point,
+    c10::optional<at::Tensor> bias) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "Prepack qlinear weight: Expected 2-dimensional weight tensor.");
+  // Weight
+  std::vector<int64_t> w_dims = weight.sizes().vec();
+  auto x_dims = input_shape.vec();
+  auto op_attr = ideep::attr_t();
+
+  // Do not need real output scale/zero point for weight packing
+  double output_scale = 1.0;
+  int64_t output_zero_point = 0;
+  ideep::scale_t weights_scales(weight_scales.numel());
+  for (int i = 0; i < weight_scales.numel(); ++i) {
+    weights_scales[i] = 1.0 / weight_scales[i].item().toDouble();
+  }
+  ideep::scale_t bias_scales, op_scales;
+  std::tie(bias_scales, op_scales) = ideep::utils::compute_scales(
+      1.0/input_scale, output_scale, weights_scales);
+  int scale_size = weights_scales.size();
+  op_attr.set_output_scales(ideep::utils::op_scale_mask(scale_size), op_scales);
+  op_attr.set_zero_points(DNNL_ARG_SRC, 0, {(int32_t)input_zero_point});
+  op_attr.set_zero_points(DNNL_ARG_DST, 0, {(int32_t)output_zero_point});
+
+  // Prepack weight
+  auto weight_copy = weight.clone();
+  ideep::tensor wgt = ideep::tensor({w_dims, dnnl::memory::data_type::s8}, weight_copy.data_ptr());
+  wgt.transpose_(0, 1); // ONEDNN requires transposed weight
+  auto w_desc = ideep::matmul_forward::expected_weights_desc(wgt.get_dims(), dnnl::memory::data_type::s8,
+                                                             dnnl::memory::data_type::u8);
+  wgt = wgt.reorder_if_differ_in(w_desc);
+  auto packed_weight = at::native::new_with_itensor_mkldnn(
+      std::move(wgt),
+      optTypeMetaToScalarType(weight.options().dtype_opt()),
+      weight.options().device_opt());
+
+  // Bias
+  at::Tensor packed_bias;
+  if (bias.has_value()) {
+    auto& b = bias.value();
+    auto bias_size = b.sizes().vec();
+    bias_size.insert(bias_size.begin(), 1);
+    TORCH_CHECK(
+        bias_size[1] == packed_weight.size(1),
+        "bias should have N elements: ",
+        std::to_string(packed_weight.size(1)),
+        ", but got ", bias_size[1]);
+    auto bias_desc = ideep::tensor::desc(bias_size, dnnl::memory::data_type::f32);
+    ideep::tensor onednn_bias;
+    onednn_bias.init(bias_desc, b.data_ptr());
+    int mask = scale_size > 1 ? 1 << (onednn_bias.ndims() - 1) : 0;
+    ideep::attr_t bias_attr = {mask, bias_scales};
+    auto expected_bias = onednn_bias.reorder_if_differ_in(bias_desc, bias_attr);
+    packed_bias = at::native::new_with_itensor_mkldnn(
+      std::move(expected_bias),
+      optTypeMetaToScalarType(b.options().dtype_opt()),
+      b.options().device_opt());
+  }
+  return std::tie(packed_weight, packed_bias);
+}
 #endif // #if AT_MKLDNN_ENABLED()
 
 namespace at {
@@ -380,6 +448,24 @@ class QLinearPackWeightFp16Legacy final {
   }
 };
 
+class QLinearPackWeightBiasInt8CpuTensor final {
+ public:
+  static std::tuple<at::Tensor, at::Tensor> run(
+    at::Tensor weight, // from CPU backend instead of QuantizedCPU
+    at::Tensor weight_scales, // Weight zero points must be 0s for onednn
+    torch::List<int64_t> input_shape,
+    double input_scale,
+    int64_t input_zero_point,
+    c10::optional<at::Tensor> bias) {
+#if AT_MKLDNN_ENABLED()
+    return prepack_qlinear_weight_bias_onednn(
+        weight, weight_scales, input_shape, input_scale, input_zero_point, bias);
+#else
+    TORCH_CHECK(false, "Unimplemented as onednn is not available.");
+#endif
+  }
+};
+
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
   register_linear_params();
   m.impl(TORCH_SELECTIVE_NAME("quantized::linear_prepack"), TORCH_FN(QLinearPackWeightInt8::run));
@@ -401,6 +487,11 @@ TORCH_LIBRARY_IMPL(_quantized, CPU, m) {
   register_linear_params();
   m.impl(TORCH_SELECTIVE_NAME("_quantized::linear_prepack_fp16"), TORCH_FN(QLinearPackWeightFp16::run));
   m.impl(TORCH_SELECTIVE_NAME("_quantized::linear_prepack_fp16_legacy"), TORCH_FN(QLinearPackWeightFp16Legacy::run));
+}
+
+  // For experiment
+TORCH_LIBRARY_IMPL(quantized, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("quantized::linear_prepack_cpu_tensor"), TORCH_FN(QLinearPackWeightBiasInt8CpuTensor::run));
 }
 
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -8,6 +8,7 @@
 #include <ATen/native/quantized/cpu/OnednnUtils.h>
 #include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <ATen/quantized/Quantizer.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <torch/custom_class.h>
 #include <torch/library.h>
 

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -193,10 +193,13 @@ TORCH_LIBRARY(quantized, m) {
   // Returns:
   //    Y: float32 Tensor
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_with_input_q_dq_qweight_dq_relu_output_fp32(Tensor X, float X_scale, int X_zero_point, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_int8_packed_weight(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, float output_scale, int output_zero_point) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_relu_int8_packed_weight(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, float output_scale, int output_zero_point) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack(Tensor W, Tensor? B=None) -> __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack_fp16(Tensor W, Tensor? B=None) -> __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack_legacy(Tensor W, Tensor? B=None) -> Tensor W_prepack"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack_fp16_legacy(Tensor W, Tensor? B=None) -> Tensor W_prepack"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_prepack_cpu_tensor(Tensor weight, Tensor w_scales, int[] x_shape, float x_scale, int x_zp, Tensor? bias) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack(__torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack_fp16(__torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::linear_unpack.legacy(Tensor W_prepack) -> (Tensor W_origin, Tensor? B_origin)"));

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -76,12 +76,17 @@ TORCH_LIBRARY(quantized, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv1d_dynamic(Tensor qx, __torch__.torch.classes.quantized.Conv2dPackedParamsBase packed_weight, bool reduce_range=False) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv2d_dynamic(Tensor qx, __torch__.torch.classes.quantized.Conv2dPackedParamsBase packed_weight, bool reduce_range=False) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv3d_dynamic(Tensor qx, __torch__.torch.classes.quantized.Conv3dPackedParamsBase packed_weight, bool reduce_range=False) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_int8_cpu_tensor(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_relu_int8_cpu_tensor(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_int8_packed_weight(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_relu_int8_packed_weight(Tensor qx, float x_scale, int x_zero_point, Tensor qw, Tensor w_scale, Tensor w_zero_point, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups, float output_scale, int output_zero_point) -> Tensor"));
 
   // conv_prepack is deprecated, please use conv2d_prepack for 2D conv.
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv2dPackedParamsBase"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv1d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv2dPackedParamsBase"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv2d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv2dPackedParamsBase"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv3d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv3dPackedParamsBase"));
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_prepack_cpu_tensor(Tensor weight, Tensor w_scales, int[] x_shape, float x_scale, int x_zp, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> (Tensor, Tensor)"));
   // conv_unpack is deprecated, please use conv2d_unpack for 2D conv.
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv_unpack(__torch__.torch.classes.quantized.Conv2dPackedParamsBase packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)"));
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::conv1d_unpack(__torch__.torch.classes.quantized.Conv2dPackedParamsBase packed_weights) -> (Tensor unpacked_weights, Tensor? B_origin)"));

--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -282,14 +282,13 @@ class TestQuantizePT2EModels(QuantizationTestCase):
     def _test_inductor_backend_helper(self, mod: torch.nn.Module, input_shape: tuple):
         import copy
         from torch import _dynamo, _inductor
-        from torch._inductor import config
         import logging
         from torch.ao.quantization import get_default_qconfig_mapping
 
-        torch._dynamo.config.log_level = logging.DEBUG
-        torch._dynamo.config.verbose = True
-        torch._inductor.config.trace.enabled = True
-        torch._inductor.config.debug = True
+        _dynamo.config.log_level = logging.DEBUG
+        _dynamo.config.verbose = True
+        _inductor.config.trace.enabled = True
+        _inductor.config.debug = True
 
         # Found some weird accuracy issue, especially with x86 backend.
         # Maybe because x86 uses reduced range, range of uint8 is 0-127.

--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -176,6 +176,53 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             self.assertTrue(torch.max(after_quant_result - after_quant_result_fx) < 1e-1)
             self.assertTrue(compute_sqnr(after_quant_result, after_quant_result_fx) > 35)
 
+    @skipIfNoONEDNN
+    def test_int8_conv_with_cpu_tensors(self):
+        bs, in_channels, out_channels = 1, 3, 16
+        feature_size, kernel_size = 224, 3
+        conv_functionals = {
+            1 : torch.ao.nn.quantized.functional.conv1d,
+            2 : torch.ao.nn.quantized.functional.conv2d,
+            3 : torch.ao.nn.quantized.functional.conv3d,
+        }
+        dimension_list = [1, 2, 3]
+        per_channel_quantize_list = [True, False]
+        use_bias_list = [True, False]
+        cases = itertools.product(dimension_list, per_channel_quantize_list, use_bias_list)
+        for dimension, per_channel_quantize, use_bias in cases:
+            x_shape = (bs, in_channels, *(feature_size,)*dimension)
+            w_shape = (out_channels, in_channels, *(kernel_size,)*dimension)
+            x = torch.ones(x_shape)
+            w = torch.ones(w_shape)
+            b = torch.ones(out_channels) if use_bias else None
+            stride = [1] * dimension
+            padding = [1] * dimension
+            dilation = [1] * dimension
+            groups = 1
+            x_scale, x_zp = 0.2, 1
+            o_scale, o_zp = 1.2, 2
+            qx = torch.quantize_per_tensor(x, scale=x_scale, zero_point=x_zp, dtype=torch.quint8)
+            if per_channel_quantize:
+                w_scales = torch.tensor([0.5] * out_channels)
+                w_zps = torch.tensor([0] * out_channels)
+                qw = torch.quantize_per_channel(w, scales=w_scales, zero_points=w_zps, axis=0, dtype=torch.qint8)
+            else:
+                w_scales = torch.tensor([0.5])
+                w_zps = torch.tensor([0])
+                qw = torch.quantize_per_tensor(w, scale=w_scales, zero_point=w_zps, dtype=torch.qint8)
+            qx_cpu = torch.tensor(qx.int_repr().tolist(), dtype=torch.uint8)
+            qw_cpu = torch.tensor(qw.int_repr().tolist(), dtype=torch.int8)
+            # prepack + compute for CPU tensor
+            result = torch.ops.quantized.conv_int8_cpu_tensor(
+                qx_cpu, x_scale, x_zp, qw_cpu, w_scales, w_zps, b,
+                stride, padding, dilation, groups, o_scale, o_zp
+            )
+            # Result for reference by functional qconv
+            result_ref = conv_functionals[dimension](
+                qx, qw, b, stride, padding, dilation, groups, scale=o_scale, zero_point=o_zp
+            )
+            self.assertEqual(result, result_ref.int_repr())
+
     def test_inductor_backend(self):
         '''
         Inductor as a quantization backend. For experiment.
@@ -232,7 +279,7 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             # second run
             inductor_result = run(*example_inputs)
 
-    def _test_conv_inductor_backend_helper(self, mod: torch.nn.Module, input_shape: tuple):
+    def _test_inductor_backend_helper(self, mod: torch.nn.Module, input_shape: tuple):
         import copy
         from torch import _dynamo, _inductor
         from torch._inductor import config
@@ -304,10 +351,15 @@ class TestQuantizePT2EModels(QuantizationTestCase):
         For experiment.
         '''
         class Mod(torch.nn.Module):
-            def __init__(self, use_relu: bool) -> None:
+            def __init__(self, with_bias: bool, use_relu: bool) -> None:
                 super().__init__()
                 self.conv = torch.nn.Conv1d(
-                    in_channels=3, out_channels=16, kernel_size=3, stride=1, padding=1
+                    in_channels=3,
+                    out_channels=16,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                    bias=with_bias
                 )
                 self.relu = torch.nn.ReLU()
                 self.use_relu = use_relu
@@ -317,11 +369,11 @@ class TestQuantizePT2EModels(QuantizationTestCase):
                 return self.relu(x) if self.use_relu else x
 
         input_shape = (1, 3, 224)
-        for use_relu in [True, False]:
-            # Only support use_relu=True now
-            if use_relu == False:
-                continue
-            self._test_conv_inductor_backend_helper(Mod(use_relu), input_shape)
+        with_bias_list = [True, False]
+        use_relu_list = [True, False]
+        cases = itertools.product(with_bias_list, use_relu_list)
+        for with_bias, use_relu in cases:
+            self._test_inductor_backend_helper(Mod(with_bias, use_relu), input_shape)
 
     def test_conv2d_inductor_backend(self):
         '''
@@ -329,10 +381,15 @@ class TestQuantizePT2EModels(QuantizationTestCase):
         For experiment.
         '''
         class Mod(torch.nn.Module):
-            def __init__(self, use_relu: bool) -> None:
+            def __init__(self, with_bias: bool, use_relu: bool) -> None:
                 super().__init__()
                 self.conv = torch.nn.Conv2d(
-                    in_channels=3, out_channels=16, kernel_size=3, stride=1, padding=1
+                    in_channels=3,
+                    out_channels=16,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                    bias=with_bias
                 )
                 self.relu = torch.nn.ReLU()
                 self.use_relu = use_relu
@@ -342,11 +399,11 @@ class TestQuantizePT2EModels(QuantizationTestCase):
                 return self.relu(x) if self.use_relu else x
 
         input_shape = (1, 3, 16, 16)
-        for use_relu in [True, False]:
-            # Only support use_relu=True now
-            if use_relu == False:
-                continue
-            self._test_conv_inductor_backend_helper(Mod(use_relu), input_shape)
+        with_bias_list = [True, False]
+        use_relu_list = [True, False]
+        cases = itertools.product(with_bias_list, use_relu_list)
+        for with_bias, use_relu in cases:
+            self._test_inductor_backend_helper(Mod(with_bias, use_relu), input_shape)
 
     def test_conv3d_inductor_backend(self):
         '''
@@ -354,10 +411,15 @@ class TestQuantizePT2EModels(QuantizationTestCase):
         For experiment.
         '''
         class Mod(torch.nn.Module):
-            def __init__(self, use_relu: bool) -> None:
+            def __init__(self, with_bias: bool, use_relu: bool) -> None:
                 super().__init__()
                 self.conv = torch.nn.Conv3d(
-                    in_channels=3, out_channels=16, kernel_size=3, stride=1, padding=1
+                    in_channels=3,
+                    out_channels=16,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                    bias=with_bias
                 )
                 self.relu = torch.nn.ReLU()
                 self.use_relu = use_relu
@@ -367,55 +429,35 @@ class TestQuantizePT2EModels(QuantizationTestCase):
                 return self.relu(x) if self.use_relu else x
 
         input_shape = (1, 3, 6, 6, 6)
-        for use_relu in [True, False]:
-            # Only support use_relu=True now
-            if use_relu == False:
-                continue
-            self._test_conv_inductor_backend_helper(Mod(use_relu), input_shape)
+        with_bias_list = [True, False]
+        use_relu_list = [True, False]
+        cases = itertools.product(with_bias_list, use_relu_list)
+        for with_bias, use_relu in cases:
+            self._test_inductor_backend_helper(Mod(with_bias, use_relu), input_shape)
 
-    @skipIfNoONEDNN
-    def test_int8_conv_with_cpu_tensors(self):
-        bs, in_channels, out_channels = 1, 3, 16
-        feature_size, kernel_size = 224, 3
-        conv_functionals = {
-            1 : torch.ao.nn.quantized.functional.conv1d,
-            2 : torch.ao.nn.quantized.functional.conv2d,
-            3 : torch.ao.nn.quantized.functional.conv3d,
-        }
-        dimension_list = [1, 2, 3]
-        per_channel_quantize_list = [True, False]
-        use_bias_list = [True, False]
-        cases = itertools.product(dimension_list, per_channel_quantize_list, use_bias_list)
-        for dimension, per_channel_quantize, use_bias in cases:
-            x_shape = (bs, in_channels, *(feature_size,)*dimension)
-            w_shape = (out_channels, in_channels, *(kernel_size,)*dimension)
-            x = torch.ones(x_shape)
-            w = torch.ones(w_shape)
-            b = torch.ones(out_channels) if use_bias else None
-            stride = [1] * dimension
-            padding = [1] * dimension
-            dilation = [1] * dimension
-            groups = 1
-            x_scale, x_zp = 0.2, 1
-            o_scale, o_zp = 1.2, 2
-            qx = torch.quantize_per_tensor(x, scale=x_scale, zero_point=x_zp, dtype=torch.quint8)
-            if per_channel_quantize:
-                w_scales = torch.tensor([0.5] * out_channels)
-                w_zps = torch.tensor([0] * out_channels)
-                qw = torch.quantize_per_channel(w, scales=w_scales, zero_points=w_zps, axis=0, dtype=torch.qint8)
-            else:
-                w_scales = torch.tensor([0.5])
-                w_zps = torch.tensor([0])
-                qw = torch.quantize_per_tensor(w, scale=w_scales, zero_point=w_zps, dtype=torch.qint8)
-            qx_cpu = torch.tensor(qx.int_repr().tolist(), dtype=torch.uint8)
-            qw_cpu = torch.tensor(qw.int_repr().tolist(), dtype=torch.int8)
-            # prepack + compute for CPU tensor
-            result = torch.ops.quantized.conv_int8_cpu_tensor(
-                qx_cpu, x_scale, x_zp, qw_cpu, w_scales, w_zps, b,
-                stride, padding, dilation, groups, o_scale, o_zp
-            )
-            # Result for reference by functional qconv
-            result_ref = conv_functionals[dimension](
-                qx, qw, b, stride, padding, dilation, groups, scale=o_scale, zero_point=o_zp
-            )
-            self.assertEqual(result, result_ref.int_repr())
+    def test_linear_inductor_backend(self):
+        '''
+        Quantize and lower linear (+ relu) with Inductor quantization backend.
+        For experiment.
+        '''
+        class Mod(torch.nn.Module):
+            def __init__(self, with_bias: bool, use_relu: bool) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(
+                    in_features=16,
+                    out_features=8,
+                    bias=with_bias
+                )
+                self.relu = torch.nn.ReLU()
+                self.use_relu = use_relu
+
+            def forward(self, x):
+                x = self.linear(x)
+                return self.relu(x) if self.use_relu else x
+
+        input_shape = (1, 16)
+        with_bias_list = [True, False]
+        use_relu_list = [True, False]
+        cases = itertools.product(with_bias_list, use_relu_list)
+        for with_bias, use_relu in cases:
+            self._test_inductor_backend_helper(Mod(with_bias, use_relu), input_shape)

--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -6,6 +6,7 @@ from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
     skip_if_no_torchvision,
     skipIfNoQNNPACK,
+    skipIfNoONEDNN,
 )
 from torch.testing._internal.common_quantization import NodeSpec as ns
 from torch.testing._internal.common_quantized import (
@@ -20,13 +21,14 @@ from torch.ao.quantization.backend_config import (
 )
 from torch.ao.quantization.backend_config._qnnpack_pt2e import get_qnnpack_pt2e_backend_config
 from torch.ao.quantization.backend_config._inductor_pt2e import get_inductor_pt2e_backend_config
-from torch.ao.quantization.quantize_fx import prepare_fx, convert_to_reference_fx
+from torch.ao.quantization.quantize_fx import prepare_fx, convert_fx, convert_to_reference_fx
 from torch.ao.quantization._quantize_pt2e import prepare_pt2e, convert_pt2e
 from torch.ao.ns.fx.utils import (
     compute_sqnr,
 )
 import copy
 from torch._inductor.compile_fx import compile_fx
+import itertools
 
 @skipIfNoQNNPACK
 class TestQuantizePT2E(QuantizationTestCase):
@@ -230,35 +232,31 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             # second run
             inductor_result = run(*example_inputs)
 
-    def test_conv2d_inductor_backend(self):
-        '''
-        Inductor as a quantization backend. For experiment.
-        '''
+    def _test_conv_inductor_backend_helper(self, mod: torch.nn.Module, input_shape: tuple):
         import copy
         from torch import _dynamo, _inductor
         from torch._inductor import config
         import logging
+        from torch.ao.quantization import get_default_qconfig_mapping
 
         torch._dynamo.config.log_level = logging.DEBUG
         torch._dynamo.config.verbose = True
         torch._inductor.config.trace.enabled = True
         torch._inductor.config.debug = True
 
-        class Mod(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.conv = torch.nn.Conv2d(
-                    in_channels=3, out_channels=16, kernel_size=3, stride=1, padding=1
-                )
-                self.relu = torch.nn.ReLU()
-
-            def forward(self, x):
-                x = self.conv(x)
-                return self.relu(x)
-
-        with override_quantized_engine("x86"):
-            example_inputs = (torch.randn(1, 3, 16, 16),)
-            m = Mod().eval()
+        # Found some weird accuracy issue, especially with x86 backend.
+        # Maybe because x86 uses reduced range, range of uint8 is 0-127.
+        # But it does not make sense. Onednn backend also faces the issue.
+        # If we use small shapes of input, checks pass.
+        qengine = 'x86'
+        with override_quantized_engine(qengine):
+            input_format = torch.contiguous_format
+            if len(input_shape) == 4:
+                input_format = torch.channels_last
+            elif len(input_shape) == 5:
+                input_format = torch.channels_last_3d
+            example_inputs = (torch.randn(input_shape).to(memory_format=input_format),)
+            m = copy.deepcopy(mod.eval())
             # program capture
             m, guards = torchdynamo.export(
                 m,
@@ -268,7 +266,7 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             )
 
             backend_config = get_inductor_pt2e_backend_config()
-            qconfig = get_default_qconfig("x86")
+            qconfig = get_default_qconfig(qengine)
             qconfig_mapping = QConfigMapping().set_global(qconfig)
             before_fusion_result = m(*example_inputs)
 
@@ -278,19 +276,146 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             m = convert_pt2e(m)
             after_quant_result = m(*example_inputs)
 
-            self.assertTrue(torch.allclose(before_fusion_result, after_quant_result, rtol=5e-02, atol=5e-02))
+            # A few ops in EXIR are not supported. Use fullgraph=False to make it work
+            # fullgraph=False by default. Here we set it explicitly as a reminder.
+            run = torch.compile(m, fullgraph=False)
 
-            # A few ops in EXIR are not supported. Set nopython=False to make it work
-            run = torch._dynamo.optimize(compile_fx, nopython=False)(m)
-
-            # first run
             inductor_result = run(*example_inputs)
 
-            module_result = m(*example_inputs)
-            self.assertEqual(inductor_result, module_result)
+            # FX quantization path
+            m2 = copy.deepcopy(mod.eval())
+            qconfig_mapping = get_default_qconfig_mapping(qengine)
+            m2 = prepare_fx(m2, qconfig_mapping, *example_inputs)
+            m2(*example_inputs)
+            m2 = convert_fx(m2)
+            eager_result = m2(*example_inputs)
+
+            # Results should match
+            self.assertEqual(inductor_result, eager_result)
 
             # second run
             inductor_result = run(*example_inputs)
+            eager_result = m2(*example_inputs)
+            self.assertEqual(inductor_result, eager_result)
 
-            self.assertTrue(torch.allclose(before_fusion_result, inductor_result, rtol=5e-02, atol=5e-02))
+    def test_conv1d_inductor_backend(self):
+        '''
+        Quantize and lower convolution 1d + relu with Inductor quantization backend.
+        For experiment.
+        '''
+        class Mod(torch.nn.Module):
+            def __init__(self, use_relu: bool) -> None:
+                super().__init__()
+                self.conv = torch.nn.Conv1d(
+                    in_channels=3, out_channels=16, kernel_size=3, stride=1, padding=1
+                )
+                self.relu = torch.nn.ReLU()
+                self.use_relu = use_relu
 
+            def forward(self, x):
+                x = self.conv(x)
+                return self.relu(x) if self.use_relu else x
+
+        input_shape = (1, 3, 224)
+        for use_relu in [True, False]:
+            # Only support use_relu=True now
+            if use_relu == False:
+                continue
+            self._test_conv_inductor_backend_helper(Mod(use_relu), input_shape)
+
+    def test_conv2d_inductor_backend(self):
+        '''
+        Quantize and lower convolution 2d + relu with Inductor quantization backend.
+        For experiment.
+        '''
+        class Mod(torch.nn.Module):
+            def __init__(self, use_relu: bool) -> None:
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=3, out_channels=16, kernel_size=3, stride=1, padding=1
+                )
+                self.relu = torch.nn.ReLU()
+                self.use_relu = use_relu
+
+            def forward(self, x):
+                x = self.conv(x)
+                return self.relu(x) if self.use_relu else x
+
+        input_shape = (1, 3, 16, 16)
+        for use_relu in [True, False]:
+            # Only support use_relu=True now
+            if use_relu == False:
+                continue
+            self._test_conv_inductor_backend_helper(Mod(use_relu), input_shape)
+
+    def test_conv3d_inductor_backend(self):
+        '''
+        Quantize and lower convolution 3d + relu with Inductor quantization backend.
+        For experiment.
+        '''
+        class Mod(torch.nn.Module):
+            def __init__(self, use_relu: bool) -> None:
+                super().__init__()
+                self.conv = torch.nn.Conv3d(
+                    in_channels=3, out_channels=16, kernel_size=3, stride=1, padding=1
+                )
+                self.relu = torch.nn.ReLU()
+                self.use_relu = use_relu
+
+            def forward(self, x):
+                x = self.conv(x)
+                return self.relu(x) if self.use_relu else x
+
+        input_shape = (1, 3, 6, 6, 6)
+        for use_relu in [True, False]:
+            # Only support use_relu=True now
+            if use_relu == False:
+                continue
+            self._test_conv_inductor_backend_helper(Mod(use_relu), input_shape)
+
+    @skipIfNoONEDNN
+    def test_int8_conv_with_cpu_tensors(self):
+        bs, in_channels, out_channels = 1, 3, 16
+        feature_size, kernel_size = 224, 3
+        conv_functionals = {
+            1 : torch.ao.nn.quantized.functional.conv1d,
+            2 : torch.ao.nn.quantized.functional.conv2d,
+            3 : torch.ao.nn.quantized.functional.conv3d,
+        }
+        dimension_list = [1, 2, 3]
+        per_channel_quantize_list = [True, False]
+        use_bias_list = [True, False]
+        cases = itertools.product(dimension_list, per_channel_quantize_list, use_bias_list)
+        for dimension, per_channel_quantize, use_bias in cases:
+            x_shape = (bs, in_channels, *(feature_size,)*dimension)
+            w_shape = (out_channels, in_channels, *(kernel_size,)*dimension)
+            x = torch.ones(x_shape)
+            w = torch.ones(w_shape)
+            b = torch.ones(out_channels) if use_bias else None
+            stride = [1] * dimension
+            padding = [1] * dimension
+            dilation = [1] * dimension
+            groups = 1
+            x_scale, x_zp = 0.2, 1
+            o_scale, o_zp = 1.2, 2
+            qx = torch.quantize_per_tensor(x, scale=x_scale, zero_point=x_zp, dtype=torch.quint8)
+            if per_channel_quantize:
+                w_scales = torch.tensor([0.5] * out_channels)
+                w_zps = torch.tensor([0] * out_channels)
+                qw = torch.quantize_per_channel(w, scales=w_scales, zero_points=w_zps, axis=0, dtype=torch.qint8)
+            else:
+                w_scales = torch.tensor([0.5])
+                w_zps = torch.tensor([0])
+                qw = torch.quantize_per_tensor(w, scale=w_scales, zero_point=w_zps, dtype=torch.qint8)
+            qx_cpu = torch.tensor(qx.int_repr().tolist(), dtype=torch.uint8)
+            qw_cpu = torch.tensor(qw.int_repr().tolist(), dtype=torch.int8)
+            # prepack + compute for CPU tensor
+            result = torch.ops.quantized.conv_int8_cpu_tensor(
+                qx_cpu, x_scale, x_zp, qw_cpu, w_scales, w_zps, b,
+                stride, padding, dilation, groups, o_scale, o_zp
+            )
+            # Result for reference by functional qconv
+            result_ref = conv_functionals[dimension](
+                qx, qw, b, stride, padding, dilation, groups, scale=o_scale, zero_point=o_zp
+            )
+            self.assertEqual(result, result_ref.int_repr())

--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -19,12 +19,14 @@ from torch.ao.quantization.backend_config import (
     get_qnnpack_backend_config,
 )
 from torch.ao.quantization.backend_config._qnnpack_pt2e import get_qnnpack_pt2e_backend_config
+from torch.ao.quantization.backend_config._inductor_pt2e import get_inductor_pt2e_backend_config
 from torch.ao.quantization.quantize_fx import prepare_fx, convert_to_reference_fx
 from torch.ao.quantization._quantize_pt2e import prepare_pt2e, convert_pt2e
 from torch.ao.ns.fx.utils import (
     compute_sqnr,
 )
 import copy
+from torch._inductor.compile_fx import compile_fx
 
 @skipIfNoQNNPACK
 class TestQuantizePT2E(QuantizationTestCase):
@@ -171,3 +173,60 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             # of quant/dequant
             self.assertTrue(torch.max(after_quant_result - after_quant_result_fx) < 1e-1)
             self.assertTrue(compute_sqnr(after_quant_result, after_quant_result_fx) > 35)
+
+    def test_inductor_backend(self):
+        '''
+        Inductor as a quantization backend. For experiment.
+        '''
+        import copy
+        from torch import _dynamo, _inductor
+        from torch._inductor import config
+        import logging
+
+        torch._dynamo.config.log_level = logging.DEBUG
+        torch._dynamo.config.verbose = True
+        torch._inductor.config.trace.enabled = True
+        torch._inductor.config.debug = True
+
+        class Mod(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(x + x)
+
+        with override_quantized_engine("x86"):
+            example_inputs = (torch.randn(1, 3, 224, 224),)
+            m = Mod().eval()
+            # program capture
+            m, guards = torchdynamo.export(
+                m,
+                *copy.deepcopy(example_inputs),
+                aten_graph=True,
+                tracing_mode="real",
+            )
+
+            backend_config = get_inductor_pt2e_backend_config()
+            qconfig = get_default_qconfig("x86")
+            qconfig_mapping = QConfigMapping().set_global(qconfig)
+            before_fusion_result = m(*example_inputs)
+
+            m = prepare_pt2e(m, qconfig_mapping, example_inputs, backend_config)
+            after_prepare_result = m(*example_inputs)
+
+            m = convert_pt2e(m)
+            after_quant_result = m(*example_inputs)
+
+            # A few ops in EXIR are not supported. Set nopython=False to make it work
+            run = torch._dynamo.optimize(compile_fx, nopython=False)(m)
+
+            # first run
+            inductor_result = run(*example_inputs)
+
+            module_result = m(*example_inputs)
+            self.assertEqual(inductor_result, module_result)
+
+            # second run
+            inductor_result = run(*example_inputs)
+

--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -230,3 +230,63 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             # second run
             inductor_result = run(*example_inputs)
 
+    def test_conv2d_inductor_backend(self):
+        '''
+        Inductor as a quantization backend. For experiment.
+        '''
+        import copy
+        from torch import _dynamo, _inductor
+        from torch._inductor import config
+        import logging
+
+        torch._dynamo.config.log_level = logging.DEBUG
+        torch._dynamo.config.verbose = True
+        torch._inductor.config.trace.enabled = True
+        torch._inductor.config.debug = True
+
+        class Mod(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = torch.nn.Conv2d(
+                    in_channels=3, out_channels=16, kernel_size=3, stride=1, padding=1
+                )
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                x = self.conv(x)
+                return self.relu(x)
+
+        with override_quantized_engine("x86"):
+            example_inputs = (torch.randn(1, 3, 224, 224),)
+            m = Mod().eval()
+            # program capture
+            m, guards = torchdynamo.export(
+                m,
+                *copy.deepcopy(example_inputs),
+                aten_graph=True,
+                tracing_mode="real",
+            )
+
+            backend_config = get_inductor_pt2e_backend_config()
+            qconfig = get_default_qconfig("x86")
+            qconfig_mapping = QConfigMapping().set_global(qconfig)
+            before_fusion_result = m(*example_inputs)
+
+            m = prepare_pt2e(m, qconfig_mapping, example_inputs, backend_config)
+            after_prepare_result = m(*example_inputs)
+
+            m = convert_pt2e(m)
+            after_quant_result = m(*example_inputs)
+
+            # A few ops in EXIR are not supported. Set nopython=False to make it work
+            run = torch._dynamo.optimize(compile_fx, nopython=False)(m)
+
+            # first run
+            inductor_result = run(*example_inputs)
+
+            module_result = m(*example_inputs)
+            self.assertEqual(inductor_result, module_result)
+
+            # second run
+            inductor_result = run(*example_inputs)
+

--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -257,7 +257,7 @@ class TestQuantizePT2EModels(QuantizationTestCase):
                 return self.relu(x)
 
         with override_quantized_engine("x86"):
-            example_inputs = (torch.randn(1, 3, 224, 224),)
+            example_inputs = (torch.randn(1, 3, 16, 16),)
             m = Mod().eval()
             # program capture
             m, guards = torchdynamo.export(
@@ -278,6 +278,8 @@ class TestQuantizePT2EModels(QuantizationTestCase):
             m = convert_pt2e(m)
             after_quant_result = m(*example_inputs)
 
+            self.assertTrue(torch.allclose(before_fusion_result, after_quant_result, rtol=5e-02, atol=5e-02))
+
             # A few ops in EXIR are not supported. Set nopython=False to make it work
             run = torch._dynamo.optimize(compile_fx, nopython=False)(m)
 
@@ -289,4 +291,6 @@ class TestQuantizePT2EModels(QuantizationTestCase):
 
             # second run
             inductor_result = run(*example_inputs)
+
+            self.assertTrue(torch.allclose(before_fusion_result, inductor_result, rtol=5e-02, atol=5e-02))
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -391,7 +391,7 @@ def compile_fx(
         # Experimental
         # fuse 'dq - op(s) - q' pattern to a quantized op
         # e.g. 'dq - aten.convolution - q' -> quantized.convNd
-        model_ = overrides.fuse_quantization(model_)
+        model_ = overrides.fuse_quantization(model_, example_inputs_)
     num_example_inputs = len(example_inputs_)
     cudagraphs = BoxedBool(
         config.triton.cudagraphs and not dynamo_config.dynamic_shapes

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -388,6 +388,10 @@ def compile_fx(
     with overrides.patch_functions():
         model_ = overrides.replace_fx(model_)
         model_ = overrides.fuse_fx(model_, example_inputs_)
+        # Experimental
+        # fuse 'dq - op(s) - q' pattern to a quantized op
+        # e.g. 'dq - aten.convolution - q' -> quantized.convNd
+        model_ = overrides.fuse_quantization(model_)
     num_example_inputs = len(example_inputs_)
     cudagraphs = BoxedBool(
         config.triton.cudagraphs and not dynamo_config.dynamic_shapes

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -37,6 +37,7 @@ from .ir import (
 )
 from .utils import ceildiv, sympy_product
 from .virtualized import ops, V
+import torch.ao.quantization.fx._decomposed
 
 log = logging.getLogger(__name__)
 lowerings = {}

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3707,6 +3707,40 @@ def _realize(x):
     return clone(x)
 
 
+@register_lowering(torch.ops.quantized_decomposed.quantize_per_tensor.tensor)
+def quantize_per_tensor_tensor(input, scale, zero_point, quant_min, quant_max, dtype):
+    quant_min_tensor = full_like(input, quant_min)
+    quant_max_tensor = full_like(input, quant_max)
+
+    def clamp(v):
+        return maximum(quant_min_tensor, minimum(quant_max_tensor, v))
+
+    output = clamp(add(round(div(input, scale)), zero_point))
+    output = to_dtype(output, dtype)
+    return output
+
+
+@register_lowering(torch.ops.quantized_decomposed.dequantize_per_tensor.tensor)
+def dequantize_per_tensor_tensor(input, scale, zero_point, quant_min, quant_max, dtype):
+    output = mul(sub(input, zero_point), scale)
+    output = to_dtype(output, torch.float32)
+    return output
+
+
+def _import_kernels():
+    """
+    Need to make sure all these get registered in the lowers dict
+    """
+    import importlib
+    import os
+
+    from . import kernel
+
+    for filename in sorted(os.listdir(os.path.dirname(kernel.__file__))):
+        if filename.endswith(".py") and filename[0] != "_":
+            importlib.import_module(f"{kernel.__name__}.{filename[:-3]}")
+
+
 # populate lowerings defined in kernel/*
 from . import kernel
 

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -615,7 +615,31 @@ def fuse_quantization(gm: torch.fx.GraphModule, example_inputs):
 
     return gm
 
-def prepack_weight_in_graph(gm: torch.fx.GraphModule):
+def _insert_packed_weight_bias(
+        gm: torch.fx.GraphModule,
+        weight_node: torch.fx.Node,
+        bias_node: torch.fx.Node,
+        q_per_channel_node: torch.fx.Node,
+        packed_weight: torch.Tensor,
+        packed_bias: torch.Tensor):
+    w_attr_name = weight_node.target
+    qw_attr_name = w_attr_name + '_quant_packed'
+    setattr(gm, qw_attr_name, packed_weight)
+    weight_node.target = qw_attr_name
+    gm.graph.owning_module._buffers[qw_attr_name] = packed_weight
+    delattr(gm, w_attr_name)
+    q_per_channel_node.replace_all_uses_with(weight_node)
+    gm.graph.erase_node(q_per_channel_node)
+    # Replace the original bias with packed bias
+    if bias_node is not None:
+        b_attr_name = bias_node.target
+        b_pack_attr_name = b_attr_name + '_packed'
+        setattr(gm, b_pack_attr_name, packed_bias)
+        bias_node.target = b_pack_attr_name
+        gm.graph.owning_module._buffers[b_pack_attr_name] = packed_bias
+        delattr(gm, b_attr_name)
+
+def _prepack_conv_weight(gm: torch.fx.GraphModule):
     for node in gm.graph.nodes:
         if node.target == torch.ops.aten.convolution.default:
             dq_per_channel = node.args[1]
@@ -644,25 +668,62 @@ def prepack_weight_in_graph(gm: torch.fx.GraphModule):
                     bias, stride, padding, dilation, groups
                 )
             # Replace the original weight with packed weight
-            w_attr_name = weight_node.target
-            qw_attr_name = w_attr_name + '_quant_packed'
-            setattr(gm, qw_attr_name, packed_weight)
-            weight_node.target = qw_attr_name
-            gm.graph.owning_module._buffers[qw_attr_name] = packed_weight
-            delattr(gm, w_attr_name)
-            q_per_channel.replace_all_uses_with(weight_node)
-            gm.graph.erase_node(q_per_channel)
-            # Replace the original bias with packed bias
-            if bias_node is not None:
-                b_attr_name = bias_node.target
-                b_pack_attr_name = b_attr_name + '_packed'
-                setattr(gm, b_pack_attr_name, packed_bias)
-                bias_node.target = b_pack_attr_name
-                gm.graph.owning_module._buffers[b_pack_attr_name] = packed_bias
-                delattr(gm, b_attr_name)
+            _insert_packed_weight_bias(
+                gm, weight_node, bias_node, q_per_channel, packed_weight, packed_bias
+            )
     gm.graph.lint()
     gm.recompile()
 
+    return gm
+
+def _prepack_linear_weight(gm: torch.fx.GraphModule):
+    """
+    Linear is decomposed to `t - addmm` (w/ bias) or `t - mm` (w/o bias)
+    To find the pattern:
+         weight - observer - t \
+         input - observer - addmm/mm
+    """
+    aten = torch.ops.aten
+    for node in gm.graph.nodes:
+        if node.target in (aten.addmm.default, aten.mm.default):
+            with_bias = (node.target == aten.addmm.default)
+            t_node = node.args[-1]
+            if t_node.target != aten.t.default:
+                continue
+            dq_per_channel = t_node.args[0]
+            if dq_per_channel.target != torch.ops.quantized_decomposed.dequantize_per_channel:
+                continue
+            q_per_channel = dq_per_channel.args[0]
+            weight_node = q_per_channel.args[0]
+            bias_node = node.args[0] if with_bias else None
+            quantize_args = \
+                (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
+            q_arg_list = list(quantize_args)
+            q_arg_tuple = tuple(q_arg_list)
+            weight_int8 = \
+                torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+            # Prepack weight into an MKLDNN tensor of dtype int8
+            w_scales = q_arg_list[1]
+            x_shape = node.args[-2].meta.get("tensor_meta").shape
+            x_scale = getattr(gm, node.args[-2].args[0].args[1].target)
+            x_zp = getattr(gm, node.args[-2].args[0].args[2].target)
+            bias = getattr(gm, bias_node.target) if bias_node is not None else None
+            packed_weight, packed_bias = \
+                torch.ops.quantized.linear_prepack_cpu_tensor(
+                    weight_int8, w_scales, x_shape, x_scale, x_zp, bias
+                )
+            # Replace the original weight with packed weight
+            _insert_packed_weight_bias(
+                gm, weight_node, bias_node, q_per_channel, packed_weight, packed_bias
+            )
+    gm.graph.lint()
+    gm.recompile()
+
+    return gm
+
+def prepack_weight_in_graph(gm: torch.fx.GraphModule):
+    gm = _prepack_conv_weight(gm)
+    gm = _prepack_linear_weight(gm)
     return gm
 
 def fuse_reference_quantized_conv(gm: torch.fx.GraphModule):

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -603,16 +603,18 @@ def fuse_quantization(gm: torch.fx.GraphModule, example_inputs):
     if not is_quantized_graph_module(gm):
         return gm
 
+    gm = prepare_dequant_for_fusion(gm)
+    pre_quantize_weights(gm)
+    gm = fuse_reference_quantized_conv(gm)
+    gm = fuse_reference_quantized_linear(gm)
+
     # To store input shapes on the graph
     # Get shape by node.meta.get("tensor_meta").shape
     from torch.fx.passes.shape_prop import ShapeProp
     fake_mode = fake_mode_from_tensors(example_inputs)
     ShapeProp(gm, fake_mode=fake_mode).propagate(*example_inputs)
 
-    gm = prepare_dequant_for_fusion(gm)
     gm = prepack_weight_in_graph(gm)
-    gm = fuse_reference_quantized_conv(gm)
-    gm = fuse_reference_quantized_linear(gm)
 
     return gm
 
@@ -666,17 +668,16 @@ def _insert_packed_weight_bias(
         gm: torch.fx.GraphModule,
         weight_node: torch.fx.Node,
         bias_node: torch.fx.Node,
-        q_per_channel_node: torch.fx.Node,
         packed_weight: torch.Tensor,
         packed_bias: torch.Tensor):
     w_attr_name = weight_node.target
-    qw_attr_name = w_attr_name + '_quant_packed'
-    setattr(gm, qw_attr_name, packed_weight)
-    weight_node.target = qw_attr_name
-    gm.graph.owning_module._buffers[qw_attr_name] = packed_weight
+    w_packed_attr_name = w_attr_name + '_packed'
+    setattr(gm, w_packed_attr_name, packed_weight)
+    weight_node.target = w_packed_attr_name
+    gm.graph.owning_module._buffers[w_packed_attr_name] = packed_weight
     delattr(gm, w_attr_name)
-    q_per_channel_node.replace_all_uses_with(weight_node)
-    gm.graph.erase_node(q_per_channel_node)
+    # q_per_channel_node.replace_all_uses_with(weight_node)
+    # gm.graph.erase_node(q_per_channel_node)
     # Replace the original bias with packed bias
     if bias_node is not None:
         b_attr_name = bias_node.target
@@ -687,28 +688,29 @@ def _insert_packed_weight_bias(
         delattr(gm, b_attr_name)
 
 def _prepack_conv_weight(gm: torch.fx.GraphModule):
+    # Assume dq - conv (- relu) - q is already fused and `w - q` is replaced by qw
+    decomposed = torch.ops.quantized_decomposed
     for node in gm.graph.nodes:
-        if node.target == torch.ops.aten.convolution.default:
-            dq_per_channel = node.args[1]
-            q_per_channel = dq_per_channel.args[0]
-            weight_node = q_per_channel.args[0]
-            bias_node = node.args[2]
-            quantize_args = \
-                (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
-            q_arg_list = list(quantize_args)
-            q_arg_tuple = tuple(q_arg_list)
-            weight_int8 = \
-                torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+        if node.target == decomposed.conv_unary_inductor:
+            # node args = (qx, x_scale, x_zp,
+            #              qw, w_scale, w_zp, w_axis,
+            #              bias, stride, padding, dilation, groups,
+            #              y_scale, y_zp, unary_post_op_name)
+            weight_node = node.args[3]
+            assert hasattr(gm, weight_node.target) and isinstance(getattr(gm, weight_node.target), torch.Tensor),\
+                    "Cannot find quantized weight of convolution" 
+            weight_int8 = getattr(gm, weight_node.target)
+            bias_node = node.args[7]
             # Prepack weight into an MKLDNN tensor of dtype int8
-            w_scales = q_arg_list[1]
+            w_scales = getattr(gm, node.args[4].target)
             x_shape = node.args[0].meta.get("tensor_meta").shape
-            x_scale = getattr(gm, node.args[0].args[0].args[1].target)
-            x_zp = getattr(gm, node.args[0].args[0].args[2].target)
+            x_scale = getattr(gm, node.args[1].target)
+            x_zp = getattr(gm, node.args[2].target)
             bias = getattr(gm, bias_node.target) if bias_node is not None else None
-            stride = node.args[3]
-            padding = node.args[4]
-            dilation = node.args[5]
-            groups = node.args[8]
+            stride = node.args[8]
+            padding = node.args[9]
+            dilation = node.args[10]
+            groups = node.args[11]
             packed_weight, packed_bias = \
                 torch.ops.quantized.conv_prepack_cpu_tensor(
                     weight_int8, w_scales, x_shape, x_scale, x_zp,
@@ -716,7 +718,7 @@ def _prepack_conv_weight(gm: torch.fx.GraphModule):
                 )
             # Replace the original weight with packed weight
             _insert_packed_weight_bias(
-                gm, weight_node, bias_node, q_per_channel, packed_weight, packed_bias
+                gm, weight_node, bias_node, packed_weight, packed_bias
             )
     gm.graph.lint()
     gm.recompile()
@@ -724,36 +726,22 @@ def _prepack_conv_weight(gm: torch.fx.GraphModule):
     return gm
 
 def _prepack_linear_weight(gm: torch.fx.GraphModule):
-    """
-    Linear is decomposed to `t - addmm` (w/ bias) or `t - mm` (w/o bias)
-    To find the pattern:
-         weight - observer - t \
-         input - observer - addmm/mm
-    """
-    aten = torch.ops.aten
+    # Assume dq - t - addmm/mm (- relu) - q is already fused and `w - q` is replaced by qw
+    decomposed = torch.ops.quantized_decomposed
     for node in gm.graph.nodes:
-        if node.target in (aten.addmm.default, aten.mm.default):
-            with_bias = (node.target == aten.addmm.default)
-            t_node = node.args[-1]
-            if t_node.target != aten.t.default:
-                continue
-            dq_per_channel = t_node.args[0]
-            if dq_per_channel.target != torch.ops.quantized_decomposed.dequantize_per_channel:
-                continue
-            q_per_channel = dq_per_channel.args[0]
-            weight_node = q_per_channel.args[0]
-            bias_node = node.args[0] if with_bias else None
-            quantize_args = \
-                (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
-            q_arg_list = list(quantize_args)
-            q_arg_tuple = tuple(q_arg_list)
-            weight_int8 = \
-                torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+        if node.target == decomposed.linear_unary_inductor:
+            # node arges = (qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
+            #               bias, y_scale, y_zp, unary_post_op_name)
+            weight_node = node.args[3]
+            assert hasattr(gm, weight_node.target) and isinstance(getattr(gm, weight_node.target), torch.Tensor),\
+                    "Cannot find quantized weight of linear" 
+            weight_int8 = getattr(gm, weight_node.target)
+            bias_node = node.args[7]
             # Prepack weight into an MKLDNN tensor of dtype int8
-            w_scales = q_arg_list[1]
-            x_shape = node.args[-2].meta.get("tensor_meta").shape
-            x_scale = getattr(gm, node.args[-2].args[0].args[1].target)
-            x_zp = getattr(gm, node.args[-2].args[0].args[2].target)
+            w_scales = getattr(gm, node.args[4].target)
+            x_shape = node.args[0].meta.get("tensor_meta").shape
+            x_scale = getattr(gm, node.args[1].target)
+            x_zp = getattr(gm, node.args[2].target)
             bias = getattr(gm, bias_node.target) if bias_node is not None else None
             packed_weight, packed_bias = \
                 torch.ops.quantized.linear_prepack_cpu_tensor(
@@ -761,7 +749,7 @@ def _prepack_linear_weight(gm: torch.fx.GraphModule):
                 )
             # Replace the original weight with packed weight
             _insert_packed_weight_bias(
-                gm, weight_node, bias_node, q_per_channel, packed_weight, packed_bias
+                gm, weight_node, bias_node, packed_weight, packed_bias
             )
     gm.graph.lint()
     gm.recompile()
@@ -772,6 +760,53 @@ def prepack_weight_in_graph(gm: torch.fx.GraphModule):
     gm = _prepack_conv_weight(gm)
     gm = _prepack_linear_weight(gm)
     return gm
+
+def _quantize_and_replace_weight(
+        gm: torch.fx.GraphModule,
+        dq_per_channel_node: torch.fx.Node):
+    # pattern: w - q - dq - weighted op
+    q_per_channel_node = dq_per_channel_node.args[0]
+    weight_node = q_per_channel_node.args[0]
+    w_attr_name = weight_node.target
+    weight = getattr(gm, w_attr_name)
+    assert isinstance(weight, torch.Tensor), 'Cannot find weight for quantization'
+    if weight.is_quantized:
+        print('Weight is already quantized. Skip.')
+        return
+    quantize_args = \
+        (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel_node.args)
+    q_arg_list = list(quantize_args)
+    q_arg_tuple = tuple(q_arg_list)
+    weight_int8 = \
+        torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+    qw_attr_name = w_attr_name + '_quant'
+    setattr(gm, qw_attr_name, weight_int8)
+    weight_node.target = qw_attr_name
+    gm.graph.owning_module._buffers[qw_attr_name] = weight_int8
+    delattr(gm, w_attr_name)
+    q_per_channel_node.replace_all_uses_with(weight_node)
+    gm.graph.erase_node(q_per_channel_node)
+
+def pre_quantize_weights(gm: torch.fx.GraphModule):
+    # pattern: w - q - dq - weighted op
+    aten = torch.ops.aten
+    decomposed = torch.ops.quantized_decomposed
+    for node in gm.graph.nodes:
+        dq_per_channel_node = None
+        if node.target == aten.convolution.default:
+            # conv args = (x, w, ...)
+            dq_per_channel_node = node.args[1]
+        elif node.target in (aten.addmm.default, aten.mm.default):
+            # linear decomposed to 't - addmm` or `t - mm`
+            # addmm args = (bias, x, t)
+            # mm args = (x, t)
+            dq_per_channel_node = node.args[-1].args[0]
+        if dq_per_channel_node is not None:
+            assert dq_per_channel_node.target == decomposed.dequantize_per_channel,\
+                    'Cannot find the dequantize op for weight'
+            _quantize_and_replace_weight(gm, dq_per_channel_node)
+    gm.graph.lint()
+    gm.recompile()
 
 def fuse_reference_quantized_conv(gm: torch.fx.GraphModule):
     """

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -598,12 +598,69 @@ def is_quantized_graph_module(gm: torch.fx.GraphModule):
             break
     return found_quantize
 
-def fuse_quantization(gm: torch.fx.GraphModule):
+def fuse_quantization(gm: torch.fx.GraphModule, example_inputs):
     # skip if gm is not a quantized graph module
     if not is_quantized_graph_module(gm):
         return gm
 
+    # To store input shapes on the graph
+    # Get shape by node.meta.get("tensor_meta").shape
+    from torch.fx.passes.shape_prop import ShapeProp
+    fake_mode = fake_mode_from_tensors(example_inputs)
+    ShapeProp(gm, fake_mode=fake_mode).propagate(*example_inputs)
+
+    gm = quantize_weight_in_graph(gm)
+
     gm = fuse_reference_quantized_conv_relu(gm)
+
+    return gm
+
+def quantize_weight_in_graph(gm: torch.fx.GraphModule):
+    for node in gm.graph.nodes:
+        if node.target == torch.ops.aten.convolution.default:
+            dq_per_channel = node.args[1]
+            q_per_channel = dq_per_channel.args[0]
+            weight_node = q_per_channel.args[0]
+            quantize_args = \
+                (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
+            q_arg_list = list(quantize_args)
+            q_arg_tuple = tuple(q_arg_list)
+            weight_int8 = \
+                torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+            # Prepack weight into an MKLDNN tensor of dtype int8
+            w_scales = q_arg_list[1]
+            x_shape = node.args[0].meta.get("tensor_meta").shape
+            x_scale = getattr(gm, node.args[0].args[0].args[1].target)
+            x_zp = getattr(gm, node.args[0].args[0].args[2].target)
+            bias = getattr(gm, node.args[2].target)
+            stride = node.args[3]
+            padding = node.args[4]
+            dilation = node.args[5]
+            groups = node.args[8]
+            packed_weight, packed_bias = \
+                torch.ops.quantized.conv_prepack_cpu_tensor(
+                    weight_int8, w_scales, x_shape, x_scale, x_zp,
+                    bias, stride, padding, dilation, groups
+                )
+            # Replace the original weight with packed weight
+            w_attr_name = weight_node.target
+            qw_attr_name = w_attr_name + '_quant_packed'
+            setattr(gm, qw_attr_name, packed_weight)
+            weight_node.target = qw_attr_name
+            gm.graph.owning_module._buffers[qw_attr_name] = packed_weight
+            delattr(gm, w_attr_name)
+            q_per_channel.replace_all_uses_with(weight_node)
+            gm.graph.erase_node(q_per_channel)
+            # Replace the original bias with packed bias
+            bias_node = node.args[2]
+            b_attr_name = bias_node.target
+            b_pack_attr_name = b_attr_name + '_packed'
+            setattr(gm, b_pack_attr_name, packed_bias)
+            bias_node.target = b_pack_attr_name
+            gm.graph.owning_module._buffers[b_pack_attr_name] = packed_bias
+            delattr(gm, b_attr_name)
+    gm.graph.lint()
+    gm.recompile()
 
     return gm
 
@@ -641,8 +698,8 @@ def fuse_reference_quantized_conv_relu(gm: torch.fx.GraphModule):
             y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
         # TODO: aten.convolution can be used for all conv1d/2d/3d but the spatial dim info
         # is lost. Here we hardcode conv2d for experiment.
-        qy = quantized_decomposed.conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
-                                                       bias, stride, padding, dilation, groups, y_scale, y_zp)
+        qy = quantized_decomposed.conv_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                                                     bias, stride, padding, dilation, groups, y_scale, y_zp)
         return qy
 
     subgraph_rewriter.replace_pattern(gm, pattern, replacement)

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -17,6 +17,7 @@ from torch.fx.passes.shape_prop import ShapeProp
 from torch.nn import functional as F
 from torch.nn.utils.fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
 from torch.overrides import TorchFunctionMode
+from torch.fx import subgraph_rewriter
 
 from . import config
 from .fx_utils import matches_module_function_pattern
@@ -579,3 +580,71 @@ replacements = {torch.nn.functional.dropout: lowmem_dropout, torch.rand_like: ra
 # Keep track of any replacement functions that use triton random,
 # so they can be avoided when fallback_random is set
 replacements_using_triton_random = {lowmem_dropout, rand_like}
+
+
+'''
+Quantization part for experiment
+TODO: Maybe move to a separate file
+'''
+def is_quantized_graph_module(gm: torch.fx.GraphModule):
+    found_quantize = False
+    quantize_ops = (
+        torch.ops.quantized_decomposed.quantize_per_tensor,
+        torch.ops.quantized_decomposed.quantize_per_channel,
+    )
+    for node in gm.graph.nodes:
+        if node.target in quantize_ops:
+            found_quantize = True
+            break
+    return found_quantize
+
+def fuse_quantization(gm: torch.fx.GraphModule):
+    # skip if gm is not a quantized graph module
+    if not is_quantized_graph_module(gm):
+        return gm
+
+    gm = fuse_reference_quantized_conv_relu(gm)
+
+    return gm
+
+def fuse_reference_quantized_conv_relu(gm: torch.fx.GraphModule):
+    """
+    For experiment
+    Currently, quantized.convNd_prepck and quantized.convNd cannot be traced by meta tensor
+    and cannot be lowered either.
+    """
+    aten = torch.ops.aten
+    quantized_decomposed = torch.ops.quantized_decomposed
+    convolution = aten.convolution.default
+    relu = aten.relu.default
+    quantize_per_tensor = quantized_decomposed.quantize_per_tensor
+    dequantize_per_tensor = quantized_decomposed.dequantize_per_tensor
+    quantize_per_channel = quantized_decomposed.quantize_per_channel
+    dequantize_per_channel = quantized_decomposed.dequantize_per_channel
+
+    def pattern(
+        qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
+        qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
+        bias, stride, padding, dilation, is_transposed, out_padding, groups,
+            y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
+        x = dequantize_per_tensor(qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype)
+        w = dequantize_per_channel(qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype)
+        y = convolution(x, w, bias, stride, padding, dilation, is_transposed, out_padding, groups)
+        y = relu(y)
+        qy = quantize_per_tensor(y, y_scale, y_zp, y_quant_min, y_quant_max, y_dtype)
+        return qy
+
+    def replacement(
+        qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
+        qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
+        bias, stride, padding, dilation, is_transposed, out_padding, groups,
+            y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
+        # TODO: aten.convolution can be used for all conv1d/2d/3d but the spatial dim info
+        # is lost. Here we hardcode conv2d for experiment.
+        quantized = torch.ops.quantized
+        w_packed = quantized.conv2d_prepack(qw, bias, stride, padding, dilation, groups)
+        qy = quantized.conv2d_relu.new(qx, w_packed, y_scale, y_zp)
+        return qy
+
+    subgraph_rewriter.replace_pattern(gm, pattern, replacement)
+    return gm

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -603,7 +603,7 @@ def fuse_quantization(gm: torch.fx.GraphModule):
     if not is_quantized_graph_module(gm):
         return gm
 
-    # gm = fuse_reference_quantized_conv_relu(gm)
+    gm = fuse_reference_quantized_conv_relu(gm)
 
     return gm
 
@@ -641,9 +641,8 @@ def fuse_reference_quantized_conv_relu(gm: torch.fx.GraphModule):
             y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
         # TODO: aten.convolution can be used for all conv1d/2d/3d but the spatial dim info
         # is lost. Here we hardcode conv2d for experiment.
-        quantized = torch.ops.quantized
-        w_packed = quantized.conv2d_prepack(qw, bias, stride, padding, dilation, groups)
-        qy = quantized.conv2d_relu.new(qx, w_packed, y_scale, y_zp)
+        qy = quantized_decomposed.conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                                                       bias, stride, padding, dilation, groups, y_scale, y_zp)
         return qy
 
     subgraph_rewriter.replace_pattern(gm, pattern, replacement)

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -609,18 +609,19 @@ def fuse_quantization(gm: torch.fx.GraphModule, example_inputs):
     fake_mode = fake_mode_from_tensors(example_inputs)
     ShapeProp(gm, fake_mode=fake_mode).propagate(*example_inputs)
 
-    gm = quantize_weight_in_graph(gm)
-
-    gm = fuse_reference_quantized_conv_relu(gm)
+    gm = prepack_weight_in_graph(gm)
+    gm = fuse_reference_quantized_conv(gm)
+    gm = fuse_reference_quantized_linear(gm)
 
     return gm
 
-def quantize_weight_in_graph(gm: torch.fx.GraphModule):
+def prepack_weight_in_graph(gm: torch.fx.GraphModule):
     for node in gm.graph.nodes:
         if node.target == torch.ops.aten.convolution.default:
             dq_per_channel = node.args[1]
             q_per_channel = dq_per_channel.args[0]
             weight_node = q_per_channel.args[0]
+            bias_node = node.args[2]
             quantize_args = \
                 (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
             q_arg_list = list(quantize_args)
@@ -632,7 +633,7 @@ def quantize_weight_in_graph(gm: torch.fx.GraphModule):
             x_shape = node.args[0].meta.get("tensor_meta").shape
             x_scale = getattr(gm, node.args[0].args[0].args[1].target)
             x_zp = getattr(gm, node.args[0].args[0].args[2].target)
-            bias = getattr(gm, node.args[2].target)
+            bias = getattr(gm, bias_node.target) if bias_node is not None else None
             stride = node.args[3]
             padding = node.args[4]
             dilation = node.args[5]
@@ -652,23 +653,21 @@ def quantize_weight_in_graph(gm: torch.fx.GraphModule):
             q_per_channel.replace_all_uses_with(weight_node)
             gm.graph.erase_node(q_per_channel)
             # Replace the original bias with packed bias
-            bias_node = node.args[2]
-            b_attr_name = bias_node.target
-            b_pack_attr_name = b_attr_name + '_packed'
-            setattr(gm, b_pack_attr_name, packed_bias)
-            bias_node.target = b_pack_attr_name
-            gm.graph.owning_module._buffers[b_pack_attr_name] = packed_bias
-            delattr(gm, b_attr_name)
+            if bias_node is not None:
+                b_attr_name = bias_node.target
+                b_pack_attr_name = b_attr_name + '_packed'
+                setattr(gm, b_pack_attr_name, packed_bias)
+                bias_node.target = b_pack_attr_name
+                gm.graph.owning_module._buffers[b_pack_attr_name] = packed_bias
+                delattr(gm, b_attr_name)
     gm.graph.lint()
     gm.recompile()
 
     return gm
 
-def fuse_reference_quantized_conv_relu(gm: torch.fx.GraphModule):
+def fuse_reference_quantized_conv(gm: torch.fx.GraphModule):
     """
     For experiment
-    Currently, quantized.convNd_prepck and quantized.convNd cannot be traced by meta tensor
-    and cannot be lowered either.
     """
     aten = torch.ops.aten
     quantized_decomposed = torch.ops.quantized_decomposed
@@ -676,33 +675,127 @@ def fuse_reference_quantized_conv_relu(gm: torch.fx.GraphModule):
     relu = aten.relu.default
     quantize_per_tensor = quantized_decomposed.quantize_per_tensor
     dequantize_per_tensor = quantized_decomposed.dequantize_per_tensor
-    quantize_per_channel = quantized_decomposed.quantize_per_channel
     dequantize_per_channel = quantized_decomposed.dequantize_per_channel
 
-    def pattern(
-        qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
-        qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
-        bias, stride, padding, dilation, is_transposed, out_padding, groups,
-            y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
-        x = dequantize_per_tensor(qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype)
-        w = dequantize_per_channel(qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype)
-        y = convolution(x, w, bias, stride, padding, dilation, is_transposed, out_padding, groups)
-        y = relu(y)
-        qy = quantize_per_tensor(y, y_scale, y_zp, y_quant_min, y_quant_max, y_dtype)
-        return qy
+    def gen_conv_pattern(unary_post_op):
+        def pattern(
+            qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
+            qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
+            bias, stride, padding, dilation, is_transposed, out_padding, groups,
+                y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
+            x = dequantize_per_tensor(qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype)
+            w = dequantize_per_channel(qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype)
+            y = convolution(x, w, bias, stride, padding, dilation, is_transposed, out_padding, groups)
+            if unary_post_op != None:
+                y = unary_post_op(y)
+            qy = quantize_per_tensor(y, y_scale, y_zp, y_quant_min, y_quant_max, y_dtype)
+            return qy
+        return pattern
 
-    def replacement(
-        qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
-        qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
-        bias, stride, padding, dilation, is_transposed, out_padding, groups,
-            y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
-        # TODO: aten.convolution can be used for all conv1d/2d/3d but the spatial dim info
-        # is lost. Here we hardcode conv2d for experiment.
-        qy = quantized_decomposed.conv_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
-                                                     bias, stride, padding, dilation, groups, y_scale, y_zp)
-        return qy
+    def gen_conv_replacement(unary_post_op_name: str):
+        def replacement(
+            qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
+            qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
+            bias, stride, padding, dilation, is_transposed, out_padding, groups,
+                y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
+            # TODO: aten.convolution can be used for all conv1d/2d/3d but the spatial dim info
+            # is lost. Here we hardcode conv2d for experiment.
+            qy = quantized_decomposed.conv_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                                                          bias, stride, padding, dilation, groups, y_scale,
+                                                          y_zp, unary_post_op_name)
+            return qy
+        return replacement
 
-    subgraph_rewriter.replace_pattern(gm, pattern, replacement)
+    unary_post_ops = {
+        'none' : None,
+        'relu' : relu,
+    }
+    for name, unary_post_op in unary_post_ops.items():
+        pattern = gen_conv_pattern(unary_post_op)
+        replacement = gen_conv_replacement(name)
+        subgraph_rewriter.replace_pattern(gm, pattern, replacement)
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+def fuse_reference_quantized_linear(gm: torch.fx.GraphModule):
+    """
+    For experiment
+    Linear is decomposed to t + addmm (with bias) or t + mm (no bias)
+    """
+    aten = torch.ops.aten
+    quantized_decomposed = torch.ops.quantized_decomposed
+    t = aten.t.default
+    addmm = aten.addmm.default # for linear with bias
+    mm = aten.mm.default # for linear without bias
+    relu = aten.relu.default
+    quantize_per_tensor = quantized_decomposed.quantize_per_tensor
+    dequantize_per_tensor = quantized_decomposed.dequantize_per_tensor
+    dequantize_per_channel = quantized_decomposed.dequantize_per_channel
+
+    def gen_addmm_pattern(unary_post_op):
+        def pattern(
+            qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
+            qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
+                bias, y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
+            x = dequantize_per_tensor(qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype)
+            w = dequantize_per_channel(qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype)
+            w_t = t(w)
+            y = addmm(bias, x, w_t)
+            if unary_post_op != None:
+                y = unary_post_op(y)
+            qy = quantize_per_tensor(y, y_scale, y_zp, y_quant_min, y_quant_max, y_dtype)
+            return qy
+        return pattern
+
+    def gen_addmm_replacement(unary_post_op_name: str):
+        def replacement(
+            qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
+            qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
+                bias, y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
+            qy = quantized_decomposed.linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                                                            bias, y_scale, y_zp, unary_post_op_name)
+            return qy
+        return replacement
+
+    def gen_mm_pattern(unary_post_op):
+        def pattern(
+            qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
+            qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
+                y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
+            x = dequantize_per_tensor(qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype)
+            w = dequantize_per_channel(qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype)
+            w_t = t(w)
+            y = mm(x, w_t)
+            if unary_post_op != None:
+                y = unary_post_op(y)
+            qy = quantize_per_tensor(y, y_scale, y_zp, y_quant_min, y_quant_max, y_dtype)
+            return qy
+        return pattern
+
+    def gen_mm_replacement(unary_post_op_name: str):
+        def replacement(
+            qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype,
+            qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype,
+                y_scale, y_zp, y_quant_min, y_quant_max, y_dtype):
+            qy = quantized_decomposed.linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                                                            None, y_scale, y_zp, unary_post_op_name)
+            return qy
+        return replacement
+
+    unary_post_ops = {
+        'none' : None,
+        'relu' : relu,
+    }
+    for name, unary_post_op in unary_post_ops.items():
+        # addmm for linear with bias
+        pattern = gen_addmm_pattern(unary_post_op)
+        replacement = gen_addmm_replacement(name)
+        subgraph_rewriter.replace_pattern(gm, pattern, replacement)
+        # mm for linear without bias
+        pattern = gen_mm_pattern(unary_post_op)
+        replacement = gen_mm_replacement(name)
+        subgraph_rewriter.replace_pattern(gm, pattern, replacement)
     gm.graph.lint()
     gm.recompile()
     return gm

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -609,11 +609,58 @@ def fuse_quantization(gm: torch.fx.GraphModule, example_inputs):
     fake_mode = fake_mode_from_tensors(example_inputs)
     ShapeProp(gm, fake_mode=fake_mode).propagate(*example_inputs)
 
+    gm = prepare_dequant_for_fusion(gm)
     gm = prepack_weight_in_graph(gm)
     gm = fuse_reference_quantized_conv(gm)
     gm = fuse_reference_quantized_linear(gm)
 
     return gm
+
+def prepare_dequant_for_fusion(gm: torch.fx.GraphModule):
+    # The pass decomposes the dequant node from:
+    # graph 1:
+    #            quant
+    #      + - - - | - - - +
+    #      |    dequant    |
+    #      |    /     \    |
+    #      |  node1  node2 |
+    #      + - | - - - | - +
+    #       quant   quant
+    # into:
+    # graph 2:
+    #            quant
+    #      + - - / - \ - - +
+    #      |dequant dequant|
+    #      |    |      |   |
+    #      | node1 node2   |
+    #      + - | - - - | - +
+    #       quant   quant
+    # In graph 1, the dequant node is shared by node1 and node2,
+    # as a result, neither node1 nor node2 could form an int8
+    # fusion pattern.
+    # After the decomposition, the graph 2 could hit the int8
+    # fusion pattern: dequant-node-quant, respectively for
+    # node1 and node2.
+    for node in gm.graph.nodes:
+        if node.target == torch.ops.quantized_decomposed.dequantize_per_tensor:
+            user_list = list(node.users)
+            if user_list.__len__() > 1:
+                # q_node, scale, zp, min, max, dtype
+                assert node.all_input_nodes.__len__() == 3, "we assume the dq per tensor node:{0} only has 3 input but get {1}".format(node, node.all_input_nodes.__len__())
+                node_before_dq_node = node.all_input_nodes[0]
+                for index in range(1, user_list.__len__()):
+                    # step1: copy dq node to new node
+                    user_node = user_list[index]
+                    # step2: connect new dq node of input and output
+                    with gm.graph.inserting_before(user_node):
+                        new_dq_node = gm.graph.call_function(torch.ops.quantized_decomposed.dequantize_per_tensor, args=node.args)
+                        new_dq_node.meta = copy.copy(node.meta)
+                        user_node.replace_input_with(node, new_dq_node)
+                
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
 
 def _insert_packed_weight_bias(
         gm: torch.fx.GraphModule,
@@ -734,6 +781,7 @@ def fuse_reference_quantized_conv(gm: torch.fx.GraphModule):
     quantized_decomposed = torch.ops.quantized_decomposed
     convolution = aten.convolution.default
     relu = aten.relu.default
+    relu_ = aten.relu_.default
     quantize_per_tensor = quantized_decomposed.quantize_per_tensor
     dequantize_per_tensor = quantized_decomposed.dequantize_per_tensor
     dequantize_per_channel = quantized_decomposed.dequantize_per_channel
@@ -770,11 +818,13 @@ def fuse_reference_quantized_conv(gm: torch.fx.GraphModule):
     unary_post_ops = {
         'none' : None,
         'relu' : relu,
+        'relu_' : relu_,
     }
     for name, unary_post_op in unary_post_ops.items():
         pattern = gen_conv_pattern(unary_post_op)
         replacement = gen_conv_replacement(name)
         subgraph_rewriter.replace_pattern(gm, pattern, replacement)
+    
     gm.graph.lint()
     gm.recompile()
     return gm

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -603,7 +603,7 @@ def fuse_quantization(gm: torch.fx.GraphModule):
     if not is_quantized_graph_module(gm):
         return gm
 
-    gm = fuse_reference_quantized_conv_relu(gm)
+    # gm = fuse_reference_quantized_conv_relu(gm)
 
     return gm
 
@@ -647,4 +647,6 @@ def fuse_reference_quantized_conv_relu(gm: torch.fx.GraphModule):
         return qy
 
     subgraph_rewriter.replace_pattern(gm, pattern, replacement)
+    gm.graph.lint()
+    gm.recompile()
     return gm

--- a/torch/ao/quantization/backend_config/_inductor_pt2e.py
+++ b/torch/ao/quantization/backend_config/_inductor_pt2e.py
@@ -64,6 +64,24 @@ def get_linear_configs():
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 2, "bias": 0})
     )
+    linear_configs.append(
+        BackendPatternConfig((torch.ops.aten.addmm.default, torch.ops.aten.relu.default))
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 2, "bias": 0})
+    )
+    linear_configs.append(
+        BackendPatternConfig(torch.ops.aten.mm.default)
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 1})
+    )
+    linear_configs.append(
+        BackendPatternConfig((torch.ops.aten.mm.default, torch.ops.aten.relu.default))
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 1})
+    )
     return linear_configs
 
 def get_conv_configs():

--- a/torch/ao/quantization/backend_config/_inductor_pt2e.py
+++ b/torch/ao/quantization/backend_config/_inductor_pt2e.py
@@ -1,0 +1,157 @@
+'''
+Based on _qnnpack_pt2e.py
+'''
+
+import operator
+import torch
+from torch.ao.quantization.backend_config import (
+    BackendConfig,
+    DTypeConfig,
+    ObservationType,
+    BackendPatternConfig,
+)
+
+weighted_op_quint8_dtype_config = DTypeConfig(
+    input_dtype=torch.quint8,
+    output_dtype=torch.quint8,
+    weight_dtype=torch.qint8,
+    bias_dtype=torch.float,
+)
+from typing import List
+
+def get_linear_configs():
+    linear_configs = []
+    observation_type = ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
+    dtype_configs = [weighted_op_quint8_dtype_config]
+
+    # TODO: need to fix the way we insert observers for this pattern
+    # should be solved in the new fusion API
+    # reason that this doesn't work: the pattern is a bit complicated and we don't
+    # have a way to specify which input of the pattern we would like to observe
+    # pattern:
+    # bias input weight
+    # \     |    /
+    #  \    |   t
+    #   \   |  /
+    #    addmm
+    # we want to observe "weight" as weight, but there is not way to convey this
+    # information with current pattern language
+    #
+    # right now:
+    # original:
+    #         weight - t \
+    #         input  - addmm
+    # observed (no hack):
+    #      weight - t - observer \
+    #       input - observer - addmm
+    # target:
+    #      weight - observer - t \
+    #        input - observer - addmm
+
+    # def root_node_getter(node_pattern):
+    #     addmm, bias, act, weight = node_pattern
+    #     return addmm
+
+    # linear_configs.append(
+    #     BackendPatternConfig((torch.ops.aten.addmm.default, MatchAllNode, MatchAllNode, torch.ops.aten.t.default))
+    #     .set_observation_type(observation_type)  # noqa: E131
+    #     .set_dtype_configs(dtype_configs)
+    #     ._set_root_node_getter(root_node_getter))
+
+    linear_configs.append(
+        BackendPatternConfig(torch.ops.aten.addmm.default)
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 2, "bias": 0})
+    )
+    return linear_configs
+
+def get_conv_configs():
+    conv_configs = []
+    observation_type = ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
+    dtype_configs = [weighted_op_quint8_dtype_config]
+    conv_configs.append(
+        BackendPatternConfig(torch.ops.aten.convolution.default)
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 1, "bias": 2})
+    )
+    conv_configs.append(
+        BackendPatternConfig((torch.ops.aten.convolution.default, torch.ops.aten.relu.default))
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 1, "bias": 2})
+    )
+    # TODO: remove when functionalization is supported in PT2 mode
+    conv_configs.append(
+        BackendPatternConfig((torch.ops.aten.convolution.default, torch.ops.aten.relu_.default))
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 1, "bias": 2})
+    )
+    return conv_configs
+
+def get_pooling_configs():
+    backend_pattern_configs = []
+    observation_type = ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT
+    dtype_configs = [weighted_op_quint8_dtype_config]
+
+    def root_node_getter(node_pattern):
+        getitem, maxpool, index = node_pattern
+        return maxpool
+
+    backend_pattern_configs.append(
+        BackendPatternConfig()
+        ._set_pattern_complex_format((operator.getitem, torch.ops.aten.max_pool2d_with_indices.default, 0))
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_root_node_getter(root_node_getter)
+    )
+
+    return backend_pattern_configs
+
+def get_relu_configs():
+    backend_pattern_configs = []
+    observation_type = ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT
+    dtype_configs = [weighted_op_quint8_dtype_config]
+    backend_pattern_configs.append(
+        BackendPatternConfig(torch.ops.aten.relu.default)
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs))
+    return backend_pattern_configs
+
+def get_binary_op_configs():
+    binary_op_configs: List[BackendPatternConfig] = []
+    dtype_configs = [weighted_op_quint8_dtype_config]
+    num_tensor_args_to_observation_type_mapping = {
+        # TODO: this is not used right now since we have extra check in prepare
+        # will need to change this to NO_OBSERVER later after we implemented
+        # Tensor dtype inference properly
+        0: ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT,
+        1: ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT,
+        2: ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT,
+    }
+    for op_with_quantized_bop_scalar_variant in [torch.ops.aten.add.Tensor, torch.ops.aten.add_.Tensor]:
+        bop_patterns = [
+            (op_with_quantized_bop_scalar_variant, torch.ops.aten.relu.default),
+            op_with_quantized_bop_scalar_variant,
+            # TODO: remove when functionalization is supported in pt2_mode
+            (op_with_quantized_bop_scalar_variant, torch.ops.aten.relu_.default),
+        ]
+        for bop_pattern in bop_patterns:
+            binary_op_configs.append(
+                BackendPatternConfig(bop_pattern)
+                    .set_dtype_configs(dtype_configs)  # noqa: E131
+                    ._set_num_tensor_args_to_observation_type(num_tensor_args_to_observation_type_mapping))
+
+    return binary_op_configs
+
+def get_inductor_pt2e_backend_config():
+    return (
+        BackendConfig("inductor_pytorch_2.0_export")
+        .set_backend_pattern_configs(get_linear_configs())
+        .set_backend_pattern_configs(get_binary_op_configs())
+        .set_backend_pattern_configs(get_conv_configs())
+        .set_backend_pattern_configs(get_pooling_configs())
+        .set_backend_pattern_configs(get_relu_configs())
+    )

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -251,14 +251,13 @@ quantized_decomposed_lib.define(
     "Tensor output_scale, Tensor output_zero_point, str unary_post_op) -> Tensor")
 
 @impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "CPU")
-def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
-                          bias, output_scale, output_zero_point, unary_post_op):
+def linear_unary_cpu(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
+                     bias, output_scale, output_zero_point, unary_post_op):
     quantized = torch.ops.quantized
 
     qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
     qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
     w_packed = quantized.linear_prepack(qw, bias)
-    
 
     if unary_post_op == 'relu':
         return quantized.linear_relu(qx, w_packed, output_scale, output_zero_point)
@@ -266,27 +265,29 @@ def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
     return quantized.linear(qx, w_packed, output_scale, output_zero_point)
 
 @impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "MkldnnCPU")
-def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
-                          bias, output_scale, output_zero_point, unary_post_op):
+def linear_unary_mkldnn_cpu(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
+                            bias, output_scale, output_zero_point, unary_post_op):
     quantized = torch.ops.quantized
 
-    qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
-    qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
-    w_packed = quantized.linear_prepack(qw, bias)
-    
-
     if unary_post_op == 'relu':
-        return quantized.linear(qx, w_packed, output_scale, output_zero_point)
+        return quantized.linear_relu_int8_packed_weight(
+            qx, x_scale, x_zp, qw, w_scale, w_zp, bias, output_scale, output_zero_point
+        )
     # Last case: unary_post_op = 'None'
-    return quantized.linear_relu(qx, w_packed, output_scale, output_zero_point)
+    return quantized.linear_int8_packed_weight(
+        qx, x_scale, x_zp, qw, w_scale, w_zp, bias, output_scale, output_zero_point
+    )
 
 @impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "Meta")
-def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
-                          output_scale, output_zero_point, unary_post_op):
-    # Shapes:
+def linear_unary_meta(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
+                      output_scale, output_zero_point, unary_post_op):
+    # Original shapes:
     # qx = [BS, IC], qw = [OC, IC], out = [BS, OC]
+    # After weight prepacking:
+    # qx = [BS, IC], qw = [IC, OC], out = [BS, OC]
+    # Assume weight is prepacked
     shape_out = list(qx.shape)
-    shape_out[-1] = qw.shape[-2]
+    shape_out[-1] = qw.shape[-1]
     out_format = torch.contiguous_format
     out = qx.new_empty(tuple(shape_out))
     out = out.to(memory_format=out_format)

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -176,34 +176,48 @@ def dequantize_per_tensor_tensor_meta(input, scale, zero_point, quant_min, quant
         raise ValueError(f"Unsupported dtype in dequantize_per_tensor: {dtype}")
 
 quantized_decomposed_lib.define(
-    "conv_relu_inductor.tensor(Tensor qx, Tensor input_scale, Tensor input_zero_point,"
+    "conv_unary_inductor.tensor(Tensor qx, Tensor input_scale, Tensor input_zero_point,"
     "Tensor qw, Tensor weight_scale, Tensor weight_zero_point, int w_axis, Tensor? bias,"
-    "int[] stride, int[] padding, int[] dilation, int groups, Tensor output_scale, Tensor output_zero_point) -> Tensor")
-@impl(quantized_decomposed_lib, "conv_relu_inductor.tensor", "CPU")
-def conv_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
-                         bias, stride, padding, dilation, groups, output_scale, output_zero_point):
+    "int[] stride, int[] padding, int[] dilation, int groups, Tensor output_scale, Tensor output_zero_point,"
+    "str unary_post_op) -> Tensor")
+@impl(quantized_decomposed_lib, "conv_unary_inductor.tensor", "CPU")
+def conv_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                        bias, stride, padding, dilation, groups, output_scale,
+                        output_zero_point, unary_post_op):
     quantized = torch.ops.quantized
 
-    qy = quantized.conv_relu_int8_cpu_tensor(
+    if unary_post_op == 'relu':
+        return quantized.conv_relu_int8_cpu_tensor(
+            qx, x_scale, x_zp, qw, w_scale, w_zp, bias,
+            stride, padding, dilation, groups, output_scale, output_zero_point
+        )
+    # Last case: unary_post_op = 'None'
+    return quantized.conv_int8_cpu_tensor(
         qx, x_scale, x_zp, qw, w_scale, w_zp, bias,
         stride, padding, dilation, groups, output_scale, output_zero_point
     )
-    return qy
 
-@impl(quantized_decomposed_lib, "conv_relu_inductor.tensor", "MkldnnCPU")
-def conv_relu_inductor_mkldnn_tensor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
-                         bias, stride, padding, dilation, groups, output_scale, output_zero_point):
+@impl(quantized_decomposed_lib, "conv_unary_inductor.tensor", "MkldnnCPU")
+def conv_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                         bias, stride, padding, dilation, groups, output_scale,
+                         output_zero_point, unary_post_op):
     quantized = torch.ops.quantized
 
-    qy = quantized.conv_relu_int8_packed_weight(
+    if unary_post_op == 'relu':
+        return quantized.conv_relu_int8_packed_weight(
+            qx, x_scale, x_zp, qw, w_scale, w_zp, bias,
+            stride, padding, dilation, groups, output_scale, output_zero_point
+        )
+    # Last case: unary_post_op = 'None'
+    return quantized.conv_int8_packed_weight(
         qx, x_scale, x_zp, qw, w_scale, w_zp, bias,
         stride, padding, dilation, groups, output_scale, output_zero_point
     )
-    return qy
 
-@impl(quantized_decomposed_lib, "conv_relu_inductor.tensor", "Meta")
-def conv_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
-                         stride, padding, dilation, groups, output_scale, output_zero_point):
+@impl(quantized_decomposed_lib, "conv_unary_inductor.tensor", "Meta")
+def conv_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
+                        stride, padding, dilation, groups, output_scale,
+                        output_zero_point, unary_post_op):
     if len(qx.shape) == 3 and len(qw.shape) == 4:
         # For conv1d, x and w should both have rank 3
         # But if weight is prepacked, it's rank is 4 by unsqueeze(2)
@@ -229,6 +243,53 @@ def conv_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
     out = out.to(memory_format=out_format)
     if len(shape_out) == 3:
         out = out.squeeze(2)
+    return out
+
+quantized_decomposed_lib.define(
+    "linear_unary_inductor.tensor(Tensor qx, Tensor input_scale, Tensor input_zero_point,"
+    "Tensor qw, Tensor weight_scale, Tensor weight_zero_point, int w_axis, Tensor? bias,"
+    "Tensor output_scale, Tensor output_zero_point, str unary_post_op) -> Tensor")
+
+@impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "CPU")
+def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                          bias, output_scale, output_zero_point, unary_post_op):
+    quantized = torch.ops.quantized
+
+    qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
+    qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
+    w_packed = quantized.linear_prepack(qw, bias)
+    
+
+    if unary_post_op == 'relu':
+        return quantized.linear_relu(qx, w_packed, output_scale, output_zero_point)
+    # Last case: unary_post_op = 'None'
+    return quantized.linear(qx, w_packed, output_scale, output_zero_point)
+
+@impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "MkldnnCPU")
+def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                          bias, output_scale, output_zero_point, unary_post_op):
+    quantized = torch.ops.quantized
+
+    qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
+    qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
+    w_packed = quantized.linear_prepack(qw, bias)
+    
+
+    if unary_post_op == 'relu':
+        return quantized.linear(qx, w_packed, output_scale, output_zero_point)
+    # Last case: unary_post_op = 'None'
+    return quantized.linear_relu(qx, w_packed, output_scale, output_zero_point)
+
+@impl(quantized_decomposed_lib, "linear_unary_inductor.tensor", "Meta")
+def linear_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
+                          output_scale, output_zero_point, unary_post_op):
+    # Shapes:
+    # qx = [BS, IC], qw = [OC, IC], out = [BS, OC]
+    shape_out = list(qx.shape)
+    shape_out[-1] = qw.shape[-2]
+    out_format = torch.contiguous_format
+    out = qx.new_empty(tuple(shape_out))
+    out = out.to(memory_format=out_format)
     return out
 
 quantized_decomposed_lib.define(

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -2,6 +2,7 @@ import torch
 from torch.library import Library, impl
 from torch.ao.quantization import MinMaxObserver
 from typing import Tuple
+from torch._meta_registrations import calc_conv_nd_return_shape
 
 # Note: decomposed means decomposed quantized tensor, using decomposed so that the
 # name is not too long
@@ -174,6 +175,41 @@ def dequantize_per_tensor_tensor_meta(input, scale, zero_point, quant_min, quant
     else:
         raise ValueError(f"Unsupported dtype in dequantize_per_tensor: {dtype}")
 
+quantized_decomposed_lib.define(
+    "conv2d_relu_inductor.tensor(Tensor qx, Tensor input_scale, Tensor input_zero_point,"
+    "Tensor qw, Tensor weight_scale, Tensor weight_zero_point, int w_axis, Tensor? bias,"
+    "int[] stride, int[] padding, int[] dilation, int groups, Tensor output_scale, Tensor output_zero_point) -> Tensor")
+@impl(quantized_decomposed_lib, "conv2d_relu_inductor.tensor", "CPU")
+def conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                         bias, stride, padding, dilation, groups, output_scale, output_zero_point):
+    quantized = torch.ops.quantized
+
+    # Input Workaround to test feasibility
+    # Re-constructure the qw and qx
+    real_qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
+    real_qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
+
+    w_packed = quantized.conv2d_prepack(real_qw, bias, stride, padding, dilation, groups)
+    qy = quantized.conv2d_relu.new(real_qx, w_packed, output_scale, output_zero_point)
+
+    # Output Workround: Return a int8 tensor without quantizer
+    return qy.int_repr()
+
+@impl(quantized_decomposed_lib, "conv2d_relu_inductor.tensor", "Meta")
+def conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
+                         stride, padding, dilation, groups, output_scale, output_zero_point):
+    shape_out = calc_conv_nd_return_shape(
+        qx,
+        qw,
+        stride,
+        padding,
+        dilation,
+        False,
+        groups,
+        None,
+    )
+    out = qx.new_empty(shape_out).to(memory_format=torch.channels_last)
+    return out
 
 quantized_decomposed_lib.define(
     "choose_qparams.tensor(Tensor input, int quant_min, int quant_max, "

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -176,31 +176,43 @@ def dequantize_per_tensor_tensor_meta(input, scale, zero_point, quant_min, quant
         raise ValueError(f"Unsupported dtype in dequantize_per_tensor: {dtype}")
 
 quantized_decomposed_lib.define(
-    "conv2d_relu_inductor.tensor(Tensor qx, Tensor input_scale, Tensor input_zero_point,"
+    "conv_relu_inductor.tensor(Tensor qx, Tensor input_scale, Tensor input_zero_point,"
     "Tensor qw, Tensor weight_scale, Tensor weight_zero_point, int w_axis, Tensor? bias,"
     "int[] stride, int[] padding, int[] dilation, int groups, Tensor output_scale, Tensor output_zero_point) -> Tensor")
-@impl(quantized_decomposed_lib, "conv2d_relu_inductor.tensor", "CPU")
-def conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+@impl(quantized_decomposed_lib, "conv_relu_inductor.tensor", "CPU")
+def conv_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
                          bias, stride, padding, dilation, groups, output_scale, output_zero_point):
     quantized = torch.ops.quantized
 
-    # Input Workaround to test feasibility
-    # Re-constructure the qw and qx
-    real_qx = torch._make_per_tensor_quantized_tensor(qx, x_scale, x_zp)
-    real_qw = torch._make_per_channel_quantized_tensor(qw, w_scale, w_zp, w_axis)
+    qy = quantized.conv_relu_int8_cpu_tensor(
+        qx, x_scale, x_zp, qw, w_scale, w_zp, bias,
+        stride, padding, dilation, groups, output_scale, output_zero_point
+    )
+    return qy
 
-    w_packed = quantized.conv2d_prepack(real_qw, bias, stride, padding, dilation, groups)
-    qy = quantized.conv2d_relu.new(real_qx, w_packed, output_scale, output_zero_point)
+@impl(quantized_decomposed_lib, "conv_relu_inductor.tensor", "MkldnnCPU")
+def conv_relu_inductor_mkldnn_tensor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, 
+                         bias, stride, padding, dilation, groups, output_scale, output_zero_point):
+    quantized = torch.ops.quantized
 
-    # Output Workround: Return a int8 tensor without quantizer
-    return qy.int_repr()
+    qy = quantized.conv_relu_int8_packed_weight(
+        qx, x_scale, x_zp, qw, w_scale, w_zp, bias,
+        stride, padding, dilation, groups, output_scale, output_zero_point
+    )
+    return qy
 
-@impl(quantized_decomposed_lib, "conv2d_relu_inductor.tensor", "Meta")
-def conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
+@impl(quantized_decomposed_lib, "conv_relu_inductor.tensor", "Meta")
+def conv_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
                          stride, padding, dilation, groups, output_scale, output_zero_point):
+    if len(qx.shape) == 3 and len(qw.shape) == 4:
+        # For conv1d, x and w should both have rank 3
+        # But if weight is prepacked, it's rank is 4 by unsqueeze(2)
+        qw_squeezed = torch.squeeze(qw, 2)
+    else:
+        qw_squeezed = qw
     shape_out = calc_conv_nd_return_shape(
         qx,
-        qw,
+        qw_squeezed,
         stride,
         padding,
         dilation,
@@ -208,7 +220,15 @@ def conv2d_relu_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis, bias,
         groups,
         None,
     )
-    out = qx.new_empty(shape_out).to(memory_format=torch.channels_last)
+    out_format = torch.channels_last
+    if len(shape_out) == 5:
+        out_format = torch.channels_last_3d
+    out = qx.new_empty(shape_out)
+    if len(shape_out) == 3:
+        out = out.unsqueeze(2)
+    out = out.to(memory_format=out_format)
+    if len(shape_out) == 3:
+        out = out.squeeze(2)
     return out
 
 quantized_decomposed_lib.define(

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -186,7 +186,7 @@ def conv_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
                         output_zero_point, unary_post_op):
     quantized = torch.ops.quantized
 
-    if unary_post_op == 'relu':
+    if unary_post_op in ['relu', 'relu_']:
         return quantized.conv_relu_int8_cpu_tensor(
             qx, x_scale, x_zp, qw, w_scale, w_zp, bias,
             stride, padding, dilation, groups, output_scale, output_zero_point
@@ -203,7 +203,7 @@ def conv_unary_inductor(qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
                          output_zero_point, unary_post_op):
     quantized = torch.ops.quantized
 
-    if unary_post_op == 'relu':
+    if unary_post_op in ['relu', 'relu_']:
         return quantized.conv_relu_int8_packed_weight(
             qx, x_scale, x_zp, qw, w_scale, w_zp, bias,
             stride, padding, dilation, groups, output_scale, output_zero_point


### PR DESCRIPTION
**Summary**
Bug fix: Prepack weight and bias for conv and linear after quantization fusion. If we prepack weight and bias before fusion, we do not know if fusion would fail or not. If fusion does not work, prepacked weight and bias cannot be used by unfused ops.

**Test plan**
python test/test_quantization.py TestQuantizePT2EModels

---

@jgong5 @leslie-fang-intel Could you review? Thanks.