### PR TITLE
[Quant][Inductor] Prepack weight for conv and linear after quantization fusion & issue fix

### DIFF
--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -25,13 +25,15 @@ namespace at { namespace native {
 
 Tensor mkldnn_to_dense(const Tensor& mkldnn_tensor, c10::optional<ScalarType> dtype) {
   TORCH_CHECK(mkldnn_tensor.scalar_type() == ScalarType::Float ||
-              mkldnn_tensor.scalar_type() == ScalarType::BFloat16,
-              "mkldnn_to_dense expects float or bfloat16 tensor input");
+              mkldnn_tensor.scalar_type() == ScalarType::BFloat16 ||
+              mkldnn_tensor.scalar_type() == ScalarType::Char,
+              "mkldnn_to_dense expects float or bfloat16 or int8 tensor input");
   ideep::tensor& stensor = itensor_from_mkldnn(mkldnn_tensor);
   auto dims = stensor.get_dims();
   auto data_type = dtype.has_value() ? dtype.value() : mkldnn_tensor.scalar_type();
-  TORCH_CHECK(data_type == ScalarType::Float || data_type == ScalarType::BFloat16,
-              "mkldnn tensor only can be converted to be a float or bfloat16 cpu tensor")
+  TORCH_CHECK(data_type == ScalarType::Float || data_type == ScalarType::BFloat16 ||
+              data_type == ScalarType::Char,
+              "mkldnn tensor only can be converted to be a float or bfloat16 or int8 cpu tensor")
   // NOTE: int32_t dims from ideep::tensor but sizes needs int64_t
   Tensor cpu_tensor = at::empty(
     std::vector<int64_t>(dims.begin(), dims.end()),
@@ -41,8 +43,11 @@ Tensor mkldnn_to_dense(const Tensor& mkldnn_tensor, c10::optional<ScalarType> dt
       data_type == ScalarType::Float
       ? stensor.to_public(cpu_tensor.template data_ptr<float>(),
                           ideep::tensor::data_type::f32)
-      : stensor.to_public(cpu_tensor.template data_ptr<BFloat16>(),
-                         ideep::tensor::data_type::bf16);
+      : data_type == ScalarType::BFloat16
+      ? stensor.to_public(cpu_tensor.template data_ptr<BFloat16>(),
+                          ideep::tensor::data_type::bf16)
+      : stensor.to_public(cpu_tensor.template data_ptr(),
+                          ideep::tensor::data_type::s8);
   cpu_tensor.as_strided_(dims, pub_tensor.get_strides());
   return cpu_tensor.contiguous();
 }

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -599,16 +599,18 @@ def fuse_quantization(gm: torch.fx.GraphModule, example_inputs):
     if not is_quantized_graph_module(gm):
         return gm
 
+    gm = prepare_dequant_for_fusion(gm)
+    pre_quantize_weights(gm)
+    gm = fuse_reference_quantized_conv(gm)
+    gm = fuse_reference_quantized_linear(gm)
+
     # To store input shapes on the graph
     # Get shape by node.meta.get("tensor_meta").shape
     from torch.fx.passes.shape_prop import ShapeProp
     fake_mode = fake_mode_from_tensors(example_inputs)
     ShapeProp(gm, fake_mode=fake_mode).propagate(*example_inputs)
 
-    gm = prepare_dequant_for_fusion(gm)
     gm = prepack_weight_in_graph(gm)
-    gm = fuse_reference_quantized_conv(gm)
-    gm = fuse_reference_quantized_linear(gm)
 
     return gm
 
@@ -662,17 +664,16 @@ def _insert_packed_weight_bias(
         gm: torch.fx.GraphModule,
         weight_node: torch.fx.Node,
         bias_node: torch.fx.Node,
-        q_per_channel_node: torch.fx.Node,
         packed_weight: torch.Tensor,
         packed_bias: torch.Tensor):
     w_attr_name = weight_node.target
-    qw_attr_name = w_attr_name + '_quant_packed'
-    setattr(gm, qw_attr_name, packed_weight)
-    weight_node.target = qw_attr_name
-    gm.graph.owning_module._buffers[qw_attr_name] = packed_weight
+    w_packed_attr_name = w_attr_name + '_packed'
+    setattr(gm, w_packed_attr_name, packed_weight)
+    weight_node.target = w_packed_attr_name
+    gm.graph.owning_module._buffers[w_packed_attr_name] = packed_weight
     delattr(gm, w_attr_name)
-    q_per_channel_node.replace_all_uses_with(weight_node)
-    gm.graph.erase_node(q_per_channel_node)
+    # q_per_channel_node.replace_all_uses_with(weight_node)
+    # gm.graph.erase_node(q_per_channel_node)
     # Replace the original bias with packed bias
     if bias_node is not None:
         b_attr_name = bias_node.target
@@ -683,28 +684,29 @@ def _insert_packed_weight_bias(
         delattr(gm, b_attr_name)
 
 def _prepack_conv_weight(gm: torch.fx.GraphModule):
+    # Assume dq - conv (- relu) - q is already fused and `w - q` is replaced by qw
+    decomposed = torch.ops.quantized_decomposed
     for node in gm.graph.nodes:
-        if node.target == torch.ops.aten.convolution.default:
-            dq_per_channel = node.args[1]
-            q_per_channel = dq_per_channel.args[0]
-            weight_node = q_per_channel.args[0]
-            bias_node = node.args[2]
-            quantize_args = \
-                (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
-            q_arg_list = list(quantize_args)
-            q_arg_tuple = tuple(q_arg_list)
-            weight_int8 = \
-                torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+        if node.target == decomposed.conv_unary_inductor:
+            # node args = (qx, x_scale, x_zp,
+            #              qw, w_scale, w_zp, w_axis,
+            #              bias, stride, padding, dilation, groups,
+            #              y_scale, y_zp, unary_post_op_name)
+            weight_node = node.args[3]
+            assert hasattr(gm, weight_node.target) and isinstance(getattr(gm, weight_node.target), torch.Tensor),\
+                    "Cannot find quantized weight of convolution" 
+            weight_int8 = getattr(gm, weight_node.target)
+            bias_node = node.args[7]
             # Prepack weight into an MKLDNN tensor of dtype int8
-            w_scales = q_arg_list[1]
+            w_scales = getattr(gm, node.args[4].target)
             x_shape = node.args[0].meta.get("tensor_meta").shape
-            x_scale = getattr(gm, node.args[0].args[0].args[1].target)
-            x_zp = getattr(gm, node.args[0].args[0].args[2].target)
+            x_scale = getattr(gm, node.args[1].target)
+            x_zp = getattr(gm, node.args[2].target)
             bias = getattr(gm, bias_node.target) if bias_node is not None else None
-            stride = node.args[3]
-            padding = node.args[4]
-            dilation = node.args[5]
-            groups = node.args[8]
+            stride = node.args[8]
+            padding = node.args[9]
+            dilation = node.args[10]
+            groups = node.args[11]
             packed_weight, packed_bias = \
                 torch.ops.quantized.conv_prepack_cpu_tensor(
                     weight_int8, w_scales, x_shape, x_scale, x_zp,
@@ -712,7 +714,7 @@ def _prepack_conv_weight(gm: torch.fx.GraphModule):
                 )
             # Replace the original weight with packed weight
             _insert_packed_weight_bias(
-                gm, weight_node, bias_node, q_per_channel, packed_weight, packed_bias
+                gm, weight_node, bias_node, packed_weight, packed_bias
             )
     gm.graph.lint()
     gm.recompile()
@@ -720,36 +722,22 @@ def _prepack_conv_weight(gm: torch.fx.GraphModule):
     return gm
 
 def _prepack_linear_weight(gm: torch.fx.GraphModule):
-    """
-    Linear is decomposed to `t - addmm` (w/ bias) or `t - mm` (w/o bias)
-    To find the pattern:
-         weight - observer - t \
-         input - observer - addmm/mm
-    """
-    aten = torch.ops.aten
+    # Assume dq - t - addmm/mm (- relu) - q is already fused and `w - q` is replaced by qw
+    decomposed = torch.ops.quantized_decomposed
     for node in gm.graph.nodes:
-        if node.target in (aten.addmm.default, aten.mm.default):
-            with_bias = (node.target == aten.addmm.default)
-            t_node = node.args[-1]
-            if t_node.target != aten.t.default:
-                continue
-            dq_per_channel = t_node.args[0]
-            if dq_per_channel.target != torch.ops.quantized_decomposed.dequantize_per_channel:
-                continue
-            q_per_channel = dq_per_channel.args[0]
-            weight_node = q_per_channel.args[0]
-            bias_node = node.args[0] if with_bias else None
-            quantize_args = \
-                (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel.args)
-            q_arg_list = list(quantize_args)
-            q_arg_tuple = tuple(q_arg_list)
-            weight_int8 = \
-                torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+        if node.target == decomposed.linear_unary_inductor:
+            # node arges = (qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
+            #               bias, y_scale, y_zp, unary_post_op_name)
+            weight_node = node.args[3]
+            assert hasattr(gm, weight_node.target) and isinstance(getattr(gm, weight_node.target), torch.Tensor),\
+                    "Cannot find quantized weight of linear" 
+            weight_int8 = getattr(gm, weight_node.target)
+            bias_node = node.args[7]
             # Prepack weight into an MKLDNN tensor of dtype int8
-            w_scales = q_arg_list[1]
-            x_shape = node.args[-2].meta.get("tensor_meta").shape
-            x_scale = getattr(gm, node.args[-2].args[0].args[1].target)
-            x_zp = getattr(gm, node.args[-2].args[0].args[2].target)
+            w_scales = getattr(gm, node.args[4].target)
+            x_shape = node.args[0].meta.get("tensor_meta").shape
+            x_scale = getattr(gm, node.args[1].target)
+            x_zp = getattr(gm, node.args[2].target)
             bias = getattr(gm, bias_node.target) if bias_node is not None else None
             packed_weight, packed_bias = \
                 torch.ops.quantized.linear_prepack_cpu_tensor(
@@ -757,7 +745,7 @@ def _prepack_linear_weight(gm: torch.fx.GraphModule):
                 )
             # Replace the original weight with packed weight
             _insert_packed_weight_bias(
-                gm, weight_node, bias_node, q_per_channel, packed_weight, packed_bias
+                gm, weight_node, bias_node, packed_weight, packed_bias
             )
     gm.graph.lint()
     gm.recompile()
@@ -768,6 +756,53 @@ def prepack_weight_in_graph(gm: torch.fx.GraphModule):
     gm = _prepack_conv_weight(gm)
     gm = _prepack_linear_weight(gm)
     return gm
+
+def _quantize_and_replace_weight(
+        gm: torch.fx.GraphModule,
+        dq_per_channel_node: torch.fx.Node):
+    # pattern: w - q - dq - weighted op
+    q_per_channel_node = dq_per_channel_node.args[0]
+    weight_node = q_per_channel_node.args[0]
+    w_attr_name = weight_node.target
+    weight = getattr(gm, w_attr_name)
+    assert isinstance(weight, torch.Tensor), 'Cannot find weight for quantization'
+    if weight.is_quantized:
+        print('Weight is already quantized. Skip.')
+        return
+    quantize_args = \
+        (getattr(gm, n.target) if isinstance(n, torch.fx.Node) else n for n in q_per_channel_node.args)
+    q_arg_list = list(quantize_args)
+    q_arg_tuple = tuple(q_arg_list)
+    weight_int8 = \
+        torch.ops.quantized_decomposed.quantize_per_channel(*q_arg_tuple)
+    qw_attr_name = w_attr_name + '_quant'
+    setattr(gm, qw_attr_name, weight_int8)
+    weight_node.target = qw_attr_name
+    gm.graph.owning_module._buffers[qw_attr_name] = weight_int8
+    delattr(gm, w_attr_name)
+    q_per_channel_node.replace_all_uses_with(weight_node)
+    gm.graph.erase_node(q_per_channel_node)
+
+def pre_quantize_weights(gm: torch.fx.GraphModule):
+    # pattern: w - q - dq - weighted op
+    aten = torch.ops.aten
+    decomposed = torch.ops.quantized_decomposed
+    for node in gm.graph.nodes:
+        dq_per_channel_node = None
+        if node.target == aten.convolution.default:
+            # conv args = (x, w, ...)
+            dq_per_channel_node = node.args[1]
+        elif node.target in (aten.addmm.default, aten.mm.default):
+            # linear decomposed to 't - addmm` or `t - mm`
+            # addmm args = (bias, x, t)
+            # mm args = (x, t)
+            dq_per_channel_node = node.args[-1].args[0]
+        if dq_per_channel_node is not None:
+            assert dq_per_channel_node.target == decomposed.dequantize_per_channel,\
+                    'Cannot find the dequantize op for weight'
+            _quantize_and_replace_weight(gm, dq_per_channel_node)
+    gm.graph.lint()
+    gm.recompile()
 
 def fuse_reference_quantized_conv(gm: torch.fx.GraphModule):
     """


### PR DESCRIPTION
**Summary**
This PR = PR https://github.com/Xia-Weiwen/pytorch/pull/22 + rebase issue fixes.

Prepack weight and bias for conv and linear after quantization fusion. If we prepack weight and bias before fusion, we do not know if fusion would fail or not. If fusion does not work, prepacked weight and bias cannot be used by unfused ops.

**Test plan**
python test/test_quantization.py TestQuantizePT2EModels

---

@jgong5 @leslie-fang-intel Please review. Thanks.