### PR TITLE
fix the op fusion issue to keep TensorMeta

### DIFF
--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -495,3 +495,32 @@ class TestQuantizePT2EModels(QuantizationTestCase):
         cases = itertools.product(with_bias_list, use_relu_list)
         for with_bias, use_relu in cases:
             self._test_inductor_backend_helper(Mod(with_bias, use_relu), input_shape)
+
+    def test_linear_relu_linear_inductor_backend(self):
+        '''
+        Test for linear to keep tensor meta.
+        For experiment.
+        '''
+        class Mod(torch.nn.Module):
+            def __init__(self, with_bias: bool) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(
+                    in_features=16,
+                    out_features=8,
+                    bias=with_bias
+                )
+                self.relu = torch.nn.ReLU()
+                self.linear2 = torch.nn.Linear(
+                    in_features=8,
+                    out_features=8,
+                    bias=with_bias
+                )
+
+            def forward(self, x):
+                x = self.linear(x)
+                return self.linear2(self.relu(x))
+
+        input_shape = (1, 16)
+        with_bias_list = [True, False]
+        for with_bias in with_bias_list:
+            self._test_inductor_backend_helper(Mod(with_bias), input_shape)

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -954,6 +954,83 @@ def fuse_reference_quantized_linear(gm: torch.fx.GraphModule):
     """
     For experiment
     Linear is decomposed to t + addmm (with bias) or t + mm (no bias)
+
+    Case1: Replace pattern:
+    # dequantize_per_channel - t -
+    # dequantize_per_tensor  -    addmm - post_op(or none) - quantize_per_tensor
+    #                   bias -
+    into new pattern:
+    # torch.ops.quantized_decomposed.linear_unary_inductor
+
+    Case2: Replace pattern:
+    # dequantize_per_channel - t -
+    # dequantize_per_tensor  -    mm - post_op(or none) - quantize_per_tensor
+    into new pattern:
+    # torch.ops.quantized_decomposed.linear_unary_inductor
+    """
+    aten = torch.ops.aten
+    quantized_decomposed = torch.ops.quantized_decomposed
+    t = aten.t.default
+    addmm = aten.addmm.default # for linear with bias
+    mm = aten.mm.default # for linear without bias
+    relu = aten.relu.default
+    quantize_per_tensor = quantized_decomposed.quantize_per_tensor
+    dequantize_per_tensor = quantized_decomposed.dequantize_per_tensor
+    dequantize_per_channel = quantized_decomposed.dequantize_per_channel
+
+    unary_post_ops = {
+        'relu' : relu,
+    }
+    for name, unary_post_op in unary_post_ops.items():
+        for node in gm.graph.nodes:
+            if node.target in [addmm, mm]:
+                if node.target is addmm:
+                    (bias, x, w_t) = node.args
+                elif node.target is mm:
+                    (x, w_t) = node.args
+                (w,) = w_t.args
+                (qw, w_scale, w_zp, w_axis, w_quant_min, w_quant_max, w_dtype) = w.args
+                (qx, x_scale, x_zp, x_quant_min, x_quant_max, x_dtype) = x.args
+                post_unary_op_is_not_none = False
+                if list(node.users)[0].target is unary_post_op:
+                    # linear relu fusion
+                    unary_op_to_be_fused = list(node.users)[0]
+                    post_unary_op_is_not_none = True
+                    if list(unary_op_to_be_fused.users)[0].target != quantize_per_tensor:
+                        # Not meet fusion pattern: the op after unary_op is not quantize_per_tensor
+                        continue
+                    quant_per_tensor_node = list(unary_op_to_be_fused.users)[0]
+                elif list(node.users)[0].target is quantize_per_tensor:
+                    quant_per_tensor_node = list(node.users)[0]
+                else:
+                    # Not meet fusion pattern: the op after linear is not unary_op to be fused or quantize_per_tensor
+                    continue
+                (y, y_scale, y_zp, y_quant_min, y_quant_max, y_dtype) = quant_per_tensor_node.args
+                with gm.graph.inserting_after(quant_per_tensor_node):
+                    args = (qx, x_scale, x_zp, qw, w_scale, w_zp, w_axis,
+                            bias if node.target is addmm else None, y_scale, y_zp, name if post_unary_op_is_not_none else "none")
+                    new_linear_node = gm.graph.call_function(quantized_decomposed.linear_unary_inductor, args=args)
+                # Copy node meta
+                new_linear_node.meta = copy.copy(quant_per_tensor_node.meta)
+                quant_per_tensor_node.replace_all_uses_with(new_linear_node)
+
+                gm.graph.erase_node(quant_per_tensor_node) # erase quantize_per_tensor
+                if post_unary_op_is_not_none:
+                    gm.graph.erase_node(unary_op_to_be_fused) # erase unary_op
+                gm.graph.erase_node(node) # erase conv
+                gm.graph.erase_node(w_t) # erase transposed node
+                gm.graph.erase_node(w) # erase dequantize_per_channel
+                gm.graph.erase_node(x) # erase dequantize_per_tensor
+
+    gm.graph.eliminate_dead_code()
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+def fuse_reference_quantized_linear_legacy(gm: torch.fx.GraphModule):
+    """
+    For experiment, use subgraph_rewriter.replace_pattern
+    Linear is decomposed to t + addmm (with bias) or t + mm (no bias)
     """
     aten = torch.ops.aten
     quantized_decomposed = torch.ops.quantized_decomposed


### PR DESCRIPTION
We need to keep the `TensorMeta` info after op fusion since it's needed to do weight prepack.
